### PR TITLE
Support multiple active mcp-remote servers

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -100,7 +100,6 @@ async function runClient(serverUrl: string, callbackPort: number, headers: Recor
 
       // Wait for the authorization code from the callback or another instance
       const code = await waitForAuthCode()
-      console.log('~~~ CLIENT - AUTH CODE ~~~', code)
 
       try {
         log('Completing authorization...')

--- a/src/client.ts
+++ b/src/client.ts
@@ -28,15 +28,16 @@ async function runClient(serverUrl: string, callbackPort: number, headers: Recor
   // Get the server URL hash for lockfile operations
   const serverUrlHash = getServerUrlHash(serverUrl)
 
-  // Coordinate authentication with other instances
-  const { server, waitForAuthCode, skipBrowserAuth } = await coordinateAuth(serverUrlHash, callbackPort, events)
-
   // Create the OAuth client provider
   const authProvider = new NodeOAuthClientProvider({
     serverUrl,
     callbackPort,
     clientName: 'MCP CLI Client',
   })
+
+  // Coordinate authentication with other instances
+  const hasSavedTokens = !!(await authProvider.tokens())
+  const { server, waitForAuthCode, skipBrowserAuth } = await coordinateAuth(serverUrlHash, callbackPort, events, hasSavedTokens)
 
   // If auth was completed by another instance, just log that we'll use the auth from disk
   if (skipBrowserAuth) {
@@ -99,6 +100,7 @@ async function runClient(serverUrl: string, callbackPort: number, headers: Recor
 
       // Wait for the authorization code from the callback or another instance
       const code = await waitForAuthCode()
+      console.log('~~~ CLIENT - AUTH CODE ~~~', code)
 
       try {
         log('Completing authorization...')

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -25,13 +25,6 @@ export async function isPidRunning(pid: number): Promise<boolean> {
  * @returns True if the lockfile is valid, false otherwise
  */
 export async function isLockValid(lockData: LockfileData): Promise<boolean> {
-  // Check if the lockfile is too old (over 30 minutes)
-  const MAX_LOCK_AGE = 30 * 60 * 1000 // 30 minutes
-  if (Date.now() - lockData.timestamp > MAX_LOCK_AGE) {
-    log('Lockfile is too old')
-    return false
-  }
-
   // Check if the process is still running
   if (!(await isPidRunning(lockData.pid))) {
     log('Process from lockfile is not running')

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -93,12 +93,14 @@ export async function waitForAuthentication(port: number): Promise<boolean> {
  * @param serverUrlHash The hash of the server URL
  * @param callbackPort The port to use for the callback server
  * @param events The event emitter to use for signaling
+ * @param hasSavedTokens Whether the client has saved tokens
  * @returns An object with the server, waitForAuthCode function, and a flag indicating if browser auth can be skipped
  */
 export async function coordinateAuth(
   serverUrlHash: string,
   callbackPort: number,
   events: EventEmitter,
+  hasSavedTokens: boolean,
 ): Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
   // Check for a lockfile (disabled on Windows for the time being)
   const lockData = process.platform === 'win32' ? null : await checkLockfile(serverUrlHash)
@@ -109,7 +111,7 @@ export async function coordinateAuth(
 
     try {
       // Try to wait for the authentication to complete
-      const authCompleted = await waitForAuthentication(lockData.port)
+      const authCompleted = hasSavedTokens || (await waitForAuthentication(lockData.port))
       if (authCompleted) {
         log('Authentication completed by another instance')
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -25,15 +25,16 @@ async function runProxy(serverUrl: string, callbackPort: number, headers: Record
   // Get the server URL hash for lockfile operations
   const serverUrlHash = getServerUrlHash(serverUrl)
 
-  // Coordinate authentication with other instances
-  const { server, waitForAuthCode, skipBrowserAuth } = await coordinateAuth(serverUrlHash, callbackPort, events)
-
   // Create the OAuth client provider
   const authProvider = new NodeOAuthClientProvider({
     serverUrl,
     callbackPort,
     clientName: 'MCP CLI Proxy',
   })
+
+  // Coordinate authentication with other instances
+  const hasSavedTokens = !!(await authProvider.tokens())
+  const { server, waitForAuthCode, skipBrowserAuth } = await coordinateAuth(serverUrlHash, callbackPort, events, hasSavedTokens)
 
   // If auth was completed by another instance, just log that we'll use the auth from disk
   if (skipBrowserAuth) {


### PR DESCRIPTION
This is my attempt to solve #25 

I found 2 main problems that were causing issues with multiple mcp-remote processes.

I already described the problems in the issue ticket but I will repeat myself here as well (with some updates to my explanation):

## Issue 1

Preconditions:
- User is not authenticated yet.
- No lock file, no tokens file.
- No active `mcp-remote` processes running.

1. When the first `mcp-remote` process is started, the auth http server is listening on port 3334 (default).
1.1. A new lockfile is created (with current timestamp and port 3334).
1.2. Auth flow starts and new token files are written to disk.
1.3. `client_info.json` contains callback url `http://127.0.0.1:3334/oauth/callback` <- please pay attention to the port being `3334` here.
2. When additional `mcp-remote` processes start, they check for an existing lock file. If the lock file is valid, auth flow uses the original process (using port `3334`). Everything is working fine here.

The tricky part begins when more than 30 minutes have passed since the original process start time. Lock files older than 30 minutes are considered invalid ([link to code](https://github.com/geelen/mcp-remote/blob/504aa2676140cb71605b514dce6584c4cebc0153/src/lib/coordination.ts#L29-L33)), therefore a new lock file will be created. However, this time the port might not be `3334` - if the original process using `3334` is still running, the process will choose a random port and this new process will become the new "master" process (responsible for auth of other processes).

The problem is that now the new process has a different port than the previous one, therefore the new callback url is different. However, `client_info.json` still contains `http://127.0.0.1:3334/oauth/callback`. This causes oauth token verification to fail on the remote server and you can no longer connect to the MCP server until you remove old tokens from `~/.mcp-auth`.

To fix it, I removed the 30 minutes timestamp limit - I believe pid + port checks might be good enough. @geelen do you remember if there was any specific reason for this check?

## Issue 2

Preconditions:
- User is authenticated and a valid auth token is saved to file.
- No active `mcp-remote` processes running.

1. The initial `mcp-remote` process is created (on default port 3334) - we now reuse the previously created tokens.
2. From now on, all future `mcp-remote` processes will fail to log in because `authCompletedPromise` is never resolved.

`authCompletedPromise` is not resolved because the first process already had valid auth token, therefore `/oauth/callback` was never called.