### PR TITLE
Supporting Azure Identity for Authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,45 @@ To bypass authentication, or to emit custom headers on all requests to your remo
 },
 ```
 
+### Azure Authentication
+
+For servers that require Azure AD/Entra ID authentication, you can use Azure Identity instead of OAuth:
+
+```json
+{
+  "mcpServers": {
+    "azure-mcp": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--auth-type", "azure",
+        "--azure-tenant-id", "${TENANT_ID}",
+        "--azure-client-id", "${CLIENT_ID}",
+        "--azure-scopes", "${SCOPES}"
+      ]
+    },
+    "env": {
+      "AZURE_TENANT_ID": "<Tenant id>",
+      "AZURE_CLIENT_ID": "<Azure SP Application ID>",
+      "AZURE_SCOPES": "<Scopes>"
+    }
+  }
+}
+```
+
+**Azure Authentication Features:**
+- Uses interactive browser authentication (no secrets required)
+- Automatic token refresh handled by Azure Identity SDK
+- Supports all Azure AD tenants and scopes
+- One-time authentication per session
+
+**Required Azure Parameters:**
+- `--auth-type azure`: Enable Azure authentication
+- `--azure-tenant-id`: Your Azure AD tenant ID
+- `--azure-client-id`: Your Azure application (client) ID
+- `--azure-scopes`: Space-separated scopes (e.g., "https://graph.microsoft.com/.default")
+
 ### Flags
 
 * If `npx` is producing errors, consider adding `-y` as the first argument to auto-accept the installation of the `mcp-remote` package.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "mcp-remote",
-  "version": "0.1.14",
-  "description": "Remote proxy for Model Context Protocol, allowing local-only clients to connect to remote servers using oAuth",
+  "name": "mcp-remote-azure",
+  "version": "0.2.0",
+  "description": "Remote proxy for Model Context Protocol with Azure Identity support, allowing local-only clients to connect to remote servers using OAuth or Azure authentication",
   "keywords": [
     "mcp",
     "stdio",
@@ -19,8 +19,8 @@
   ],
   "main": "dist/index.js",
   "bin": {
-    "mcp-remote": "dist/proxy.js",
-    "mcp-remote-client": "dist/client.js"
+    "mcp-remote-azure": "dist/proxy.js",
+    "mcp-remote-azure-client": "dist/client.js"
   },
   "scripts": {
     "build": "tsup",
@@ -29,6 +29,7 @@
     "lint-fix": "prettier --check . --write"
   },
   "dependencies": {
+    "@azure/identity": "^4.4.1",
     "express": "^4.21.2",
     "open": "^10.1.0"
   },

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,27 @@ export interface OAuthCallbackServerOptions {
   events: EventEmitter
 }
 
-// optional tatic OAuth client information
+// optional static OAuth client information
 export type StaticOAuthClientMetadata = OAuthClientMetadata | null | undefined
 export type StaticOAuthClientInformationFull = OAuthClientInformationFull | null | undefined
+
+/**
+ * Azure Identity configuration options
+ */
+export interface AzureAuthOptions {
+  /** Azure tenant ID */
+  tenantId: string
+  /** Azure client/application ID */
+  clientId: string
+  /** Scopes to request (space or array separated) */
+  scopes: string[]
+  /** Optional redirect URI for interactive flows */
+  redirectUri?: string
+  /** Optional authority URL (defaults to public cloud) */
+  authority?: string
+}
+
+/**
+ * Authentication type configuration
+ */
+export type AuthType = 'oauth' | 'azure'


### PR DESCRIPTION
For MCP servers that rely on Azure identity for authentication (MSAL, MISE, etc), this PR adds support for interactive login when the local MCP proxy is starting, sending the generated JWT token for the given audience, in every request.
This enables remote HTTP MCP servers to fully authorize Azure tokens within each request.