### PR TITLE
fix: omit oauth scopes when authorization server advertises scopes_supported: []

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -289,6 +289,37 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       expect(clientMetadata.scope).toBe('openid email')
     })
 
+    it('should omit scope when authorization server advertises scopes_supported: []', () => {
+      const metadata: AuthorizationServerMetadata = {
+        issuer: 'https://example.com',
+        scopes_supported: [],
+      }
+
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        authorizationServerMetadata: metadata,
+      })
+
+      expect(provider.clientMetadata.scope).toBeUndefined()
+    })
+
+    it('should omit scope query param when scopes_supported is []', async () => {
+      const metadata: AuthorizationServerMetadata = {
+        issuer: 'https://example.com',
+        scopes_supported: [],
+      }
+
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        authorizationServerMetadata: metadata,
+      })
+
+      const authUrl = new URL('https://auth.example.com/authorize')
+      await provider.redirectToAuthorization(authUrl)
+
+      expect(authUrl.searchParams.has('scope')).toBe(false)
+    })
+
     it('should treat empty scope string as no scope and use default', () => {
       provider = new NodeOAuthClientProvider({
         ...defaultOptions,

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -72,7 +72,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       software_id: this.softwareId,
       software_version: this.softwareVersion,
       ...this.staticOAuthClientMetadata,
-      scope: effectiveScope,
+      ...(effectiveScope ? { scope: effectiveScope } : {}),
     }
   }
 
@@ -135,17 +135,22 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       return this._clientInfo.scope
     }
 
-    // Priority 5: Use authorization server's supported scopes if available
-    if (this.authorizationServerMetadata?.scopes_supported?.length) {
-      const scope = this.authorizationServerMetadata.scopes_supported.join(' ')
+    // Priority 5: Use authorization server's supported scopes if advertised
+    const authScopes = this.authorizationServerMetadata?.scopes_supported
+    if (authScopes !== undefined) {
+      if (authScopes.length === 0) {
+        debugLog('Authorization server advertises no scopes (scopes_supported: []), omitting scope')
+        return ''
+      }
+      const scope = authScopes.join(' ')
       debugLog('Using scopes from Authorization Server Metadata', {
-        scopes_supported: this.authorizationServerMetadata.scopes_supported,
+        scopes_supported: authScopes,
         scope,
       })
       return scope
     }
 
-    // Priority 6: Fallback to hardcoded default
+    // Priority 6: Fallback to hardcoded default when metadata is unknown or omits scopes_supported
     debugLog('Using fallback default scope')
     return 'openid email profile'
   }
@@ -263,8 +268,12 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
 
     const effectiveScope = this.getEffectiveScope()
-    authorizationUrl.searchParams.set('scope', effectiveScope)
-    debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    if (effectiveScope) {
+      authorizationUrl.searchParams.set('scope', effectiveScope)
+      debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    } else {
+      debugLog('Omitting scope parameter from authorization URL (no effective scope)')
+    }
 
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 


### PR DESCRIPTION
## Problem

OAuth authorize fails with `invalid_scope` for servers whose AS metadata includes `"scopes_supported": []`. The client was falling through to a hardcoded `openid email profile` default, which those servers do not support.

This bug was uncovered trying to connect to Datadog's MCP, which advertises `"scopes_supported": []`.

The fix has been tested against Datadog's MCP:

```bash
$ git checkout main
$ npm run build
$ node dist/client.js https://mcp.datadoghq.com/api/unstable/mcp-server/mcp
# ^-- does not work - datadog reports "<client> will have no permissions"

$ git checkout fix/oauth-empty-scopes-supported
$ npm run build
$ node dist/client.js https://mcp.datadoghq.com/api/unstable/mcp-server/mcp
# ^-- works correctly
```

## Fix

- If `authorizationServerMetadata.scopes_supported` is present and empty, treat that as **no scopes** and return an empty effective scope.
- Only set the `scope` query param on the authorize URL and only include `scope` in dynamic client metadata when the effective scope is non-empty.
- When metadata omits `scopes_supported` entirely, keep the existing OIDC fallback so behavior stays the same for unknown servers.

## Tests

- Assert client metadata omits `scope` when `scopes_supported: []`
- Assert authorize URL has no `scope` param in that case

Refs: RFC 6749 §3.3 (omitted scope → server default or error); servers advertising an empty supported list should not receive unrelated OIDC scopes.

Made with [Cursor](https://cursor.com)