### PR TITLE
fix: automatically include Accept: application/json, text/event-stream header when making requests to Streamable HTTP endpoints

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -411,7 +411,7 @@ export async function connectToRemoteServer(
               : (init?.headers as Record<string, string>) || {}),
             ...headers,
             ...(tokens?.access_token ? { Authorization: `Bearer ${tokens.access_token}` } : {}),
-            Accept: 'text/event-stream',
+            Accept: 'application/json, text/event-stream',
           } as Record<string, string>,
         }),
       )


### PR DESCRIPTION
## Problem
mcp-remote returns 406 Not Acceptable when connecting to MCP servers 
using the Streamable HTTP transport (e.g. AWS Lambda, FastMCP).

The MCP spec (2025-03-26) REQUIRES the client to send:
  Accept: application/json, text/event-stream

Reference: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports#streamable-http

> "The client MUST include an Accept header, listing both 
> application/json and text/event-stream as supported content types."

When users pass --header flags, requestInit.headers is populated but 
the Accept header is never included, causing servers to reject with 406.

## Fix
Explicitly set `Accept: application/json, text/event-stream` as a 
default in the requestInit.headers passed to StreamableHTTPClientTransport,
before spreading user-provided headers so they can still override if needed.

## Reproduction
curl -X POST <lambda-url>/mcp \
  -H "Content-Type: application/json" \
  # Without Accept → 406 Not Acceptable
  # With Accept: application/json, text/event-stream → 200 OK ✅

## Related
- MCP spec: https://modelcontextprotocol.io/specification/2025-03-26/basic/transports
- SDK headers bug: https://github.com/modelcontextprotocol/typescript-sdk/issues/495