### PR TITLE
fix: omit scope parameter when server does not support scopes

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -73,11 +73,11 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       expect(metadata.scope).toBe('openid email profile read:user')
     })
 
-    it('should fallback to default scopes when none provided', () => {
+    it('should fallback to no scope when none provided', () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       const metadata = provider.clientMetadata
-      expect(metadata.scope).toBe('openid email profile')
+      expect(metadata.scope).toBeUndefined()
     })
   })
 
@@ -96,13 +96,13 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       expect(authUrl.searchParams.get('scope')).toBe('github read:user')
     })
 
-    it('should include default scope in authorization URL when none specified', async () => {
+    it('should omit scope from authorization URL when none specified', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       const authUrl = new URL('https://auth.example.com/authorize')
       await provider.redirectToAuthorization(authUrl)
 
-      expect(authUrl.searchParams.get('scope')).toBe('openid email profile')
+      expect(authUrl.searchParams.has('scope')).toBe(false)
     })
   })
 
@@ -132,7 +132,7 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
   })
 
   describe('credential invalidation', () => {
-    it('should reset to default scopes after client invalidation', async () => {
+    it('should reset to no scope after client invalidation', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       const clientInfo = {
@@ -147,7 +147,7 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
 
       await provider.invalidateCredentials('client')
 
-      expect(provider.clientMetadata.scope).toBe('openid email profile')
+      expect(provider.clientMetadata.scope).toBeUndefined()
       expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', 'client_info.json')
     })
 
@@ -218,7 +218,7 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       expect(clientMetadata.scope).toBe('custom:read custom:write special:scope')
     })
 
-    it('should use scopes when scopes_supported is empty', () => {
+    it('should not include scope in client metadata when scopes_supported is empty', () => {
       const metadata: AuthorizationServerMetadata = {
         issuer: 'https://example.com',
         scopes_supported: [],
@@ -234,6 +234,24 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
 
       const clientMetadata = provider.clientMetadata
       expect(clientMetadata.scope).toBe('custom:read custom:write')
+    })
+
+    it('should omit scope from authorization URL when server declares empty scopes_supported', async () => {
+      const metadata: AuthorizationServerMetadata = {
+        issuer: 'https://example.com',
+        scopes_supported: [],
+      }
+
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        authorizationServerMetadata: metadata,
+      })
+
+      const authUrl = new URL('https://auth.example.com/authorize')
+      await provider.redirectToAuthorization(authUrl)
+
+      // When no scopes are available, scope param should be omitted entirely
+      expect(authUrl.searchParams.has('scope')).toBe(false)
     })
 
     it('should use scopes when no metadata is provided', () => {
@@ -289,7 +307,29 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       expect(clientMetadata.scope).toBe('openid email')
     })
 
-    it('should treat empty scope string as no scope and use default', () => {
+    it('should omit scope when scopes_supported is empty and no other sources', () => {
+      const metadata: AuthorizationServerMetadata = {
+        issuer: 'https://example.com',
+        scopes_supported: [],
+      }
+
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        authorizationServerMetadata: metadata,
+      })
+
+      const clientMetadata = provider.clientMetadata
+      expect(clientMetadata.scope).toBeUndefined()
+    })
+
+    it('should omit scope when no metadata is provided and no other sources', () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      const clientMetadata = provider.clientMetadata
+      expect(clientMetadata.scope).toBeUndefined()
+    })
+
+    it('should treat empty scope string as no scope and omit it', () => {
       provider = new NodeOAuthClientProvider({
         ...defaultOptions,
         staticOAuthClientMetadata: {
@@ -298,8 +338,8 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       })
 
       const clientMetadata = provider.clientMetadata
-      // Empty scope should fallback to default
-      expect(clientMetadata.scope).toBe('openid email profile')
+      // Empty scope should be omitted entirely
+      expect(clientMetadata.scope).toBeUndefined()
     })
   })
 })

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -62,6 +62,9 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
   get clientMetadata() {
     const effectiveScope = this.getEffectiveScope()
+    // Destructure scope out of staticOAuthClientMetadata to prevent it from
+    // overriding the computed effectiveScope via object spread.
+    const { scope: _staticScope, ...staticMetadataWithoutScope } = this.staticOAuthClientMetadata || {}
     return {
       redirect_uris: [this.redirectUrl],
       token_endpoint_auth_method: 'none',
@@ -71,8 +74,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       client_uri: this.clientUri,
       software_id: this.softwareId,
       software_version: this.softwareVersion,
-      ...this.staticOAuthClientMetadata,
-      scope: effectiveScope,
+      ...staticMetadataWithoutScope,
+      ...(effectiveScope != null ? { scope: effectiveScope } : {}),
     }
   }
 
@@ -106,7 +109,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
   }
 
-  private getEffectiveScope(): string {
+  private getEffectiveScope(): string | undefined {
     // Priority 1: User-provided scope from staticOAuthClientMetadata (highest priority)
     if (this.staticOAuthClientMetadata?.scope && this.staticOAuthClientMetadata.scope.trim().length > 0) {
       debugLog('Using scope from staticOAuthClientMetadata', { scope: this.staticOAuthClientMetadata.scope })
@@ -145,9 +148,11 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       return scope
     }
 
-    // Priority 6: Fallback to hardcoded default
-    debugLog('Using fallback default scope')
-    return 'openid email profile'
+    // No scopes available — the server does not require scopes (e.g. Datadog MCP).
+    // Return undefined so the scope parameter is omitted from requests entirely,
+    // rather than sending a hardcoded default that the server may reject.
+    debugLog('No scopes found from any source, omitting scope parameter')
+    return undefined
   }
 
   /**
@@ -263,8 +268,12 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
 
     const effectiveScope = this.getEffectiveScope()
-    authorizationUrl.searchParams.set('scope', effectiveScope)
-    debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    if (effectiveScope != null) {
+      authorizationUrl.searchParams.set('scope', effectiveScope)
+      debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    } else {
+      debugLog('No scope to add to authorization URL')
+    }
 
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 


### PR DESCRIPTION
## Problem

When an OAuth server declares `scopes_supported: []` (or omits scopes entirely), `getEffectiveScope()` falls through all resolution steps and returns the hardcoded fallback `"openid email profile"`. This scope is then **unconditionally** appended to the authorization URL via `searchParams.set("scope", effectiveScope)`.

Servers that do not use scopes — such as the **Datadog MCP server** (`mcp.datadoghq.eu`) — reject those OIDC scopes with `error=invalid_scope`, making OAuth authorization fail completely.

### How to reproduce

```bash
npx mcp-remote https://mcp.datadoghq.eu/api/unstable/mcp-server/mcp
```

The authorization URL that opens in the browser includes `&scope=openid+email+profile`. After authorizing, the callback returns `error=invalid_scope`.

Datadog's own OAuth metadata confirms it doesn't support any scopes:

```
GET https://mcp.datadoghq.eu/.well-known/oauth-authorization-server

{
  "issuer": "https://mcp.datadoghq.eu",
  "scopes_supported": [],
  ...
}
```

### Root cause

The scope resolution chain in `getEffectiveScope()` skips empty values at every level:

1. `staticOAuthClientMetadata.scope` — skipped if empty (`.trim().length > 0`)
2. `wwwAuthenticateScope` — skipped if empty
3. `protectedResourceMetadata.scopes_supported` — skipped if `[]` (`.length` check)
4. `_clientInfo.scope` — skipped if empty
5. `authorizationServerMetadata.scopes_supported` — skipped if `[]`
6. **Hardcoded fallback: `return "openid email profile"`** ← always reached

And in `redirectToAuthorization()`, the scope is always set:
```ts
authorizationUrl.searchParams.set("scope", effectiveScope)
```

There is no way for a user or server to signal "no scopes needed" — every path either requires a non-empty value or falls through to the OIDC default.

### Fix

- `getEffectiveScope()` now returns `undefined` instead of a hardcoded fallback when no scope source provides a value.
- `clientMetadata` omits the `scope` property when undefined. It also destructures `scope` out of `staticOAuthClientMetadata` to prevent an empty-string scope from leaking via object spread.
- `redirectToAuthorization()` only sets the `scope` query parameter when a scope is available.

### Impact

- **Servers with scopes** (e.g. Slack, GitHub): No behavior change — their scopes are still resolved via the existing priority chain and included in the authorization URL.
- **Servers without scopes** (e.g. Datadog): The `scope` parameter is now omitted from the authorization URL, allowing the OAuth flow to complete successfully.

### Tests

All existing tests updated. New test cases added:
- `should omit scope when scopes_supported is empty and no other sources`
- `should omit scope when no metadata is provided and no other sources`
- `should omit scope from authorization URL when server declares empty scopes_supported`
- `should treat empty scope string as no scope and omit it`

All 106 tests pass.