### PR TITLE
fix: recover from EADDRINUSE on OAuth callback port instead of crashing

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -32,6 +32,7 @@ import { createLazyAuthCoordinator } from './lib/coordination'
 async function runClient(
   serverUrl: string,
   callbackPort: number,
+  specifiedPort: number | undefined,
   headers: Record<string, string>,
   transportStrategy: TransportStrategy = 'http-first',
   host: string,
@@ -43,8 +44,10 @@ async function runClient(
   // Set up event emitter for auth flow
   const events = new EventEmitter()
 
+  const strictPort = !!specifiedPort || !!staticOAuthClientInfo
+
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, strictPort)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -96,6 +99,16 @@ async function runClient(
 
     // Store server in outer scope for cleanup
     server = authState.server
+
+    // If the callback server bound to a different port (EADDRINUSE fallback), update the provider
+    if (authState.actualPort !== callbackPort) {
+      log(`Callback port changed from ${callbackPort} to ${authState.actualPort} (original port was unavailable)`)
+      authProvider.setCallbackPort(authState.actualPort)
+      if (!staticOAuthClientInfo) {
+        log('Invalidating cached client registration so it re-registers with the new redirect_uri')
+        await authProvider.invalidateCredentials('client')
+      }
+    }
 
     // If auth was completed by another instance, just log that we'll use the auth from disk
     if (authState.skipBrowserAuth) {
@@ -183,6 +196,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
     ({
       serverUrl,
       callbackPort,
+      specifiedPort,
       headers,
       transportStrategy,
       host,
@@ -194,6 +208,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
       return runClient(
         serverUrl,
         callbackPort,
+        specifiedPort,
         headers,
         transportStrategy,
         host,

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -7,7 +7,7 @@ import { unlinkSync } from 'fs'
 import { log, debugLog, setupOAuthCallbackServerWithLongPoll } from './utils'
 
 export type AuthCoordinator = {
-  initializeAuth: () => Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }>
+  initializeAuth: () => Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean; actualPort: number }>
 }
 
 /**
@@ -126,6 +126,7 @@ export async function waitForAuthentication(port: number): Promise<boolean> {
  * @param serverUrlHash The hash of the server URL
  * @param callbackPort The port to use for the callback server
  * @param events The event emitter to use for signaling
+ * @param strictPort If true, fail rather than fall back to a random port on EADDRINUSE
  * @returns An AuthCoordinator object with an initializeAuth method
  */
 export function createLazyAuthCoordinator(
@@ -133,8 +134,9 @@ export function createLazyAuthCoordinator(
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
+  strictPort = false,
 ): AuthCoordinator {
-  let authState: { server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean } | null = null
+  let authState: { server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean; actualPort: number } | null = null
 
   return {
     initializeAuth: async () => {
@@ -148,8 +150,8 @@ export function createLazyAuthCoordinator(
       debugLog('Initializing auth coordination on-demand', { serverUrlHash, callbackPort })
 
       // Initialize auth using the existing coordinateAuth logic
-      authState = await coordinateAuth(serverUrlHash, callbackPort, events, authTimeoutMs)
-      debugLog('Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth })
+      authState = await coordinateAuth(serverUrlHash, callbackPort, events, authTimeoutMs, strictPort)
+      debugLog('Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth, actualPort: authState.actualPort })
       return authState
     },
   }
@@ -160,14 +162,16 @@ export function createLazyAuthCoordinator(
  * @param serverUrlHash The hash of the server URL
  * @param callbackPort The port to use for the callback server
  * @param events The event emitter to use for signaling
- * @returns An object with the server, waitForAuthCode function, and a flag indicating if browser auth can be skipped
+ * @param strictPort If true, fail rather than fall back to a random port on EADDRINUSE
+ * @returns An object with the server, actualPort, waitForAuthCode function, and a flag indicating if browser auth can be skipped
  */
 export async function coordinateAuth(
   serverUrlHash: string,
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
-): Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
+  strictPort = false,
+): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
   debugLog('Coordinating authentication', { serverUrlHash, callbackPort })
 
   // Check for a lockfile (disabled on Windows for the time being)
@@ -205,6 +209,7 @@ export async function coordinateAuth(
 
         return {
           server: dummyServer,
+          actualPort: dummyPort,
           waitForAuthCode: dummyWaitForAuthCode,
           skipBrowserAuth: true,
         }
@@ -227,25 +232,14 @@ export async function coordinateAuth(
 
   // Create our own lockfile
   debugLog('Setting up OAuth callback server', { port: callbackPort })
-  const { server, waitForAuthCode, authCompletedPromise } = setupOAuthCallbackServerWithLongPoll({
+  const { server, actualPort, waitForAuthCode } = await setupOAuthCallbackServerWithLongPoll({
     port: callbackPort,
     path: '/oauth/callback',
     events,
     authTimeoutMs,
+    strictPort,
   })
 
-  // Get the actual port the server is running on
-  let address = server.address() as AddressInfo | null
-  if (!address) {
-    await new Promise<void>((resolve) => server.once('listening', resolve))
-    address = server.address() as AddressInfo | null
-  }
-
-  if (!address) {
-    throw new Error('Failed to get server address after listening event')
-  }
-
-  const actualPort = address.port
   debugLog('OAuth callback server running', { port: actualPort })
 
   log(`Creating lockfile for server ${serverUrlHash} with process ${process.pid} on port ${actualPort}`)
@@ -282,6 +276,7 @@ export async function coordinateAuth(
   debugLog('Auth coordination complete, returning primary instance handlers')
   return {
     server,
+    actualPort,
     waitForAuthCode,
     skipBrowserAuth: false,
   }

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -56,6 +56,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     this.wwwAuthenticateScope = options.wwwAuthenticateScope
   }
 
+  setCallbackPort(port: number): void {
+    this.options.callbackPort = port
+  }
+
   get redirectUrl(): string {
     return `http://${this.options.host}:${this.options.callbackPort}${this.callbackPath}`
   }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -53,6 +53,8 @@ export interface OAuthCallbackServerOptions {
   events: EventEmitter
   /** Timeout in milliseconds for the auth callback server's long poll */
   authTimeoutMs?: number
+  /** If true, fail with an error when the port is unavailable instead of falling back to a random port */
+  strictPort?: boolean
 }
 
 // optional tatic OAuth client information

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -998,7 +998,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
 
   it('should use custom timeout when authTimeoutMs is provided', async () => {
     const customTimeout = 5000
-    const result = setupOAuthCallbackServerWithLongPoll({
+    const result = await setupOAuthCallbackServerWithLongPoll({
       port: 0, // Use any available port
       path: '/oauth/callback',
       events,
@@ -1013,7 +1013,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
   })
 
   it('should use default timeout when authTimeoutMs is not provided', async () => {
-    const result = setupOAuthCallbackServerWithLongPoll({
+    const result = await setupOAuthCallbackServerWithLongPoll({
       port: 0, // Use any available port
       path: '/oauth/callback',
       events,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -3,6 +3,7 @@ import { parseCommandLineArgs, shouldIncludeTool, mcpProxy, setupOAuthCallbackSe
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { EventEmitter } from 'events'
 import express from 'express'
+import net from 'net'
 
 // All sanitizeUrl tests have been moved to the strict-url-sanitise package
 
@@ -1024,6 +1025,64 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
     // Test that the server was created with defaults
     expect(server).toBeDefined()
     expect(typeof result.waitForAuthCode).toBe('function')
+  })
+
+  it('should return actualPort matching the bound port on success', async () => {
+    const result = await setupOAuthCallbackServerWithLongPoll({
+      port: 0,
+      path: '/oauth/callback',
+      events,
+    })
+
+    server = result.server
+    const boundPort = (server.address() as net.AddressInfo).port
+    expect(result.actualPort).toBe(boundPort)
+    expect(result.actualPort).toBeGreaterThan(0)
+  })
+
+  it('should fall back to a random port when the requested port is already in use', async () => {
+    // Hold a port so the callback server cannot bind to it
+    const blocker = net.createServer()
+    const blockedPort = await new Promise<number>((resolve) => {
+      blocker.listen(0, '127.0.0.1', () => resolve((blocker.address() as net.AddressInfo).port))
+    })
+
+    try {
+      const result = await setupOAuthCallbackServerWithLongPoll({
+        port: blockedPort,
+        path: '/oauth/callback',
+        events,
+      })
+
+      server = result.server
+      expect(result.actualPort).toBeGreaterThan(0)
+      expect(result.actualPort).not.toBe(blockedPort)
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()))
+    }
+  })
+
+  it('should reject with EADDRINUSE error when strictPort is true and port is already in use', async () => {
+    const blocker = net.createServer()
+    const blockedPort = await new Promise<number>((resolve) => {
+      blocker.listen(0, '127.0.0.1', () => resolve((blocker.address() as net.AddressInfo).port))
+    })
+
+    try {
+      await expect(
+        setupOAuthCallbackServerWithLongPoll({
+          port: blockedPort,
+          path: '/oauth/callback',
+          events,
+          strictPort: true,
+        }),
+      ).rejects.toMatchObject({
+        code: 'EADDRINUSE',
+        requestedPort: blockedPort,
+      })
+    } finally {
+      await new Promise<void>((resolve) => blocker.close(() => resolve()))
+    }
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -15,7 +15,8 @@ import {
 } from './protected-resource-metadata'
 import { fetchAuthorizationServerMetadata, type AuthorizationServerMetadata } from './authorization-server-metadata'
 import express from 'express'
-import net from 'net'
+import net, { AddressInfo } from 'net'
+import { Server } from 'http'
 import crypto from 'crypto'
 import fs from 'fs'
 import { readFile, rm } from 'fs/promises'
@@ -566,9 +567,17 @@ export async function connectToRemoteServer(
 /**
  * Sets up an Express server to handle OAuth callbacks
  * @param options The server options
- * @returns An object with the server, authCode, and waitForAuthCode function
+ * @returns A promise resolving to an object with the server, actualPort, authCode, and waitForAuthCode function
  */
-export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServerOptions) {
+export async function setupOAuthCallbackServerWithLongPoll(
+  options: OAuthCallbackServerOptions,
+): Promise<{
+  server: Server
+  actualPort: number
+  authCode: string | null
+  waitForAuthCode: () => Promise<string>
+  authCompletedPromise: Promise<string>
+}> {
   let authCode: string | null = null
   const app = express()
 
@@ -645,8 +654,42 @@ export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServe
     options.events.emit('auth-code-received', code)
   })
 
-  const server = app.listen(options.port, '127.0.0.1', () => {
-    log(`OAuth callback server running at http://127.0.0.1:${options.port}`)
+  // Bind the server, falling back to a random port on EADDRINUSE (unless strictPort is set)
+  const { server, actualPort } = await new Promise<{ server: Server; actualPort: number }>((resolve, reject) => {
+    const httpServer = app.listen(options.port, '127.0.0.1')
+
+    httpServer.once('error', (err: NodeJS.ErrnoException) => {
+      if (err.code === 'EADDRINUSE') {
+        if (options.strictPort) {
+          reject(
+            Object.assign(
+              new Error(
+                `Callback port ${options.port} is already in use. The port is mandatory (it was specified explicitly or is pinned by --static-oauth-client-info). Close the process holding that port or restart your machine.`,
+              ),
+              { code: 'EADDRINUSE', requestedPort: options.port },
+            ),
+          )
+          return
+        }
+        log(`Warning: callback port ${options.port} is already in use, falling back to a random port`)
+        // Retry with an OS-assigned port
+        const fallback = app.listen(0, '127.0.0.1')
+        fallback.once('error', reject)
+        fallback.once('listening', () => {
+          const addr = fallback.address() as AddressInfo
+          log(`OAuth callback server running at http://127.0.0.1:${addr.port} (fallback from ${options.port})`)
+          resolve({ server: fallback, actualPort: addr.port })
+        })
+      } else {
+        reject(err)
+      }
+    })
+
+    httpServer.once('listening', () => {
+      const addr = httpServer.address() as AddressInfo
+      log(`OAuth callback server running at http://127.0.0.1:${addr.port}`)
+      resolve({ server: httpServer, actualPort: addr.port })
+    })
   })
 
   const waitForAuthCode = (): Promise<string> => {
@@ -662,16 +705,16 @@ export function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbackServe
     })
   }
 
-  return { server, authCode, waitForAuthCode, authCompletedPromise }
+  return { server, actualPort, authCode, waitForAuthCode, authCompletedPromise }
 }
 
 /**
  * Sets up an Express server to handle OAuth callbacks
  * @param options The server options
- * @returns An object with the server, authCode, and waitForAuthCode function
+ * @returns A promise resolving to an object with the server, authCode, and waitForAuthCode function
  */
-export function setupOAuthCallbackServer(options: OAuthCallbackServerOptions) {
-  const { server, authCode, waitForAuthCode } = setupOAuthCallbackServerWithLongPoll(options)
+export async function setupOAuthCallbackServer(options: OAuthCallbackServerOptions) {
+  const { server, authCode, waitForAuthCode } = await setupOAuthCallbackServerWithLongPoll(options)
   return { server, authCode, waitForAuthCode }
 }
 
@@ -932,6 +975,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
   return {
     serverUrl,
     callbackPort,
+    specifiedPort,
     headers,
     transportStrategy,
     host,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -31,6 +31,7 @@ import { createLazyAuthCoordinator } from './lib/coordination'
 async function runProxy(
   serverUrl: string,
   callbackPort: number,
+  specifiedPort: number | undefined,
   headers: Record<string, string>,
   transportStrategy: TransportStrategy = 'http-first',
   host: string,
@@ -44,8 +45,10 @@ async function runProxy(
   // Set up event emitter for auth flow
   const events = new EventEmitter()
 
+  const strictPort = !!specifiedPort || !!staticOAuthClientInfo
+
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, strictPort)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -90,6 +93,16 @@ async function runProxy(
 
     // Store server in outer scope for cleanup
     server = authState.server
+
+    // If the callback server bound to a different port (EADDRINUSE fallback), update the provider
+    if (authState.actualPort !== callbackPort) {
+      log(`Callback port changed from ${callbackPort} to ${authState.actualPort} (original port was unavailable)`)
+      authProvider.setCallbackPort(authState.actualPort)
+      if (!staticOAuthClientInfo) {
+        log('Invalidating cached client registration so it re-registers with the new redirect_uri')
+        await authProvider.invalidateCredentials('client')
+      }
+    }
 
     // If auth was completed by another instance, just log that we'll use the auth from disk
     if (authState.skipBrowserAuth) {
@@ -170,6 +183,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
     ({
       serverUrl,
       callbackPort,
+      specifiedPort,
       headers,
       transportStrategy,
       host,
@@ -184,6 +198,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
       return runProxy(
         serverUrl,
         callbackPort,
+        specifiedPort,
         headers,
         transportStrategy,
         host,


### PR DESCRIPTION
## Problem

When a previous mcp-remote process exits uncleanly (e.g. Claude Desktop is force-closed), the OAuth callback server it was hosting stays bound to its port. On the next launch, mcp-remote reads the same port from cached client_info.json, calls app.listen(port) with no 'error' handler, and crashes with EADDRINUSE. 

There is no automatic recovery, the user is stuck until they manually kill the orphaned Node process.

Closes #253

## Solution

Make app.listen() authoritative over port availability by wrapping it in a Promise with an explicit 'error' handler:

- On EADDRINUSE (default): log a warning and retry with app.listen(0) to get an OS-assigned port. Propagate the actual bound port back through the auth coordinator so `NodeOAuthClientProvider` can update its `redirect_uri` before the auth flow runs. If the port changed and dynamic registration is in use, invalidate the cached `client_info.json` so the SDK re-registers with the correct `redirect_uri`.
- On EADDRINUSE with strictPort: true: reject with an actionable error message instead of silently rebinding. strictPort is set when the user explicitly passed a [callback-port] argument or when `--static-oauth-client-info` is used (because those pre-configure a fixed `redirect_uri`).

## Changes

- **src/lib/types.ts**: Add `strictPort?: boolean` to `OAuthCallbackServerOptions`
- **src/lib/utils.ts**: `setupOAuthCallbackServerWithLongPoll` is now async, returns actualPort; EADDRINUSE fallback logic added; specifiedPort added to `parseCommandLineArgs` return
- **src/lib/coordination.ts**: `coordinateAuth` and `AuthCoordinator` carry actualPort through; strictPort threaded down from `createLazyAuthCoordinator`
- **src/lib/node-oauth-client-provider.ts**: Add `setCallbackPort(port)` to allow the provider's `redirect_uri` to be updated after bind
- **src/proxy.ts / src/client.ts**: Detect port change after `initializeAuth`, call `setCallbackPort` and conditionally invalidate client registration; pass strictPort into coordinator

## Behaviour

Normal reconnect where stale process holds the port:

1. app.listen(22129) → EADDRINUSE → fallback app.listen(0) → binds e.g. 54321
2. Proxy logs: Callback port changed from 22129 to 54321 (original port was unavailable)
3. client_info.json cleared → SDK re-registers with redirect_uris: ["http://localhost:54321/oauth/callback"]
4. Auth completes on port 54321 → tools work

- Strict port (explicit arg or static client info):
`Error: Callback port 22129 is already in use. The port is mandatory (it was specified explicitly or is pinned by --static-oauth-client-info). Close the process holding that port or restart your machine.`

- Happy path (port free): identical to previous behaviour.
