### PR TITLE
fix: add Accept-Encoding: identity to OAuth discovery fetch requests

### DIFF
--- a/src/lib/authorization-server-metadata.test.ts
+++ b/src/lib/authorization-server-metadata.test.ts
@@ -53,6 +53,7 @@ describe('authorization-server-metadata', () => {
         expect.objectContaining({
           headers: {
             Accept: 'application/json',
+            'Accept-Encoding': 'identity',
           },
         }),
       )

--- a/src/lib/authorization-server-metadata.ts
+++ b/src/lib/authorization-server-metadata.ts
@@ -52,6 +52,7 @@ export async function fetchAuthorizationServerMetadata(serverUrl: string): Promi
     const response = await fetch(metadataUrl, {
       headers: {
         Accept: 'application/json',
+        'Accept-Encoding': 'identity',
       },
       // Short timeout to avoid blocking
       signal: AbortSignal.timeout(5000),

--- a/src/lib/protected-resource-metadata.test.ts
+++ b/src/lib/protected-resource-metadata.test.ts
@@ -152,7 +152,7 @@ describe('protected-resource-metadata', () => {
       expect(global.fetch).toHaveBeenCalledWith(
         'https://mcp.example.com/.well-known/oauth-protected-resource/mcp',
         expect.objectContaining({
-          headers: { Accept: 'application/json' },
+          headers: { Accept: 'application/json', 'Accept-Encoding': 'identity' },
         }),
       )
     })

--- a/src/lib/protected-resource-metadata.ts
+++ b/src/lib/protected-resource-metadata.ts
@@ -133,6 +133,7 @@ async function fetchProtectedResourceMetadataFromUrl(metadataUrl: string): Promi
     const response = await fetch(metadataUrl, {
       headers: {
         Accept: 'application/json',
+        'Accept-Encoding': 'identity',
       },
       signal: AbortSignal.timeout(5000),
     })


### PR DESCRIPTION
## Summary

On Node 26, `fetch` (undici) sends `Accept-Encoding: gzip, deflate, br` by default. `fetchAuthorizationServerMetadata` and `fetchProtectedResourceMetadata` set `Accept: application/json` but not `Accept-Encoding`, so Cloudflare-fronted servers (e.g. `mcp.atlassian.com`) return gzip-compressed bodies that `response.json()` cannot parse. This crashes `mcp-remote` at OAuth discovery before the transport is initialized.

## Related Issues

- Closes #278

## Changes

- Added `'Accept-Encoding': 'identity'` to `fetch()` headers in `fetchAuthorizationServerMetadata` (`src/lib/authorization-server-metadata.ts`)
- Added `'Accept-Encoding': 'identity'` to `fetch()` headers in `fetchProtectedResourceMetadata` (`src/lib/protected-resource-metadata.ts`)
- Updated header assertions in both test files to match

## Test Plan

- Unit tests: `pnpm test:unit` (103 tests, all pass)
- Type check + formatting: `pnpm check` (clean)
- Build: `pnpm build` (clean)
- Backward compatible: servers that do not compress are unaffected; verified with curl against `mcp.atlassian.com` for all three cases (no `Accept-Encoding`, gzip, identity)

## Verification Checklist

- [x] Tests pass: `pnpm test:unit`
- [x] Type check clean: `pnpm check`
- [x] Build clean: `pnpm build`
- [x] No scope creep (two fetch call sites + matching test assertions only)
- [x] No secrets or credentials in diff
- [x] I have reviewed every line in this PR and can explain it
