### PR TITLE
Handle CLI info flags before URL parsing

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -178,7 +178,7 @@ async function runClient(
 }
 
 // Parse command-line arguments and run the client
-parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://server-url> [callback-port] [--debug]')
+parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote-client <https://server-url> [callback-port] [--debug]')
   .then(
     ({
       serverUrl,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -7,6 +7,40 @@ import express from 'express'
 // All sanitizeUrl tests have been moved to the strict-url-sanitise package
 
 describe('Feature: Command Line Arguments Parsing', () => {
+  it('Scenario: Show help without parsing server URL', async () => {
+    // Given command line arguments with only the help flag
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as any)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`process.exit:${code}`)
+    })
+
+    // When parsing the command line arguments
+    await expect(parseCommandLineArgs(['--help'], 'test usage')).rejects.toThrow('process.exit:0')
+
+    // Then usage should be written before URL validation
+    expect(stdoutSpy).toHaveBeenCalledWith('test usage\n')
+
+    stdoutSpy.mockRestore()
+    exitSpy.mockRestore()
+  })
+
+  it('Scenario: Show version without parsing server URL', async () => {
+    // Given command line arguments with only the version flag
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation((() => true) as any)
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation((code?: string | number | null | undefined) => {
+      throw new Error(`process.exit:${code}`)
+    })
+
+    // When parsing the command line arguments
+    await expect(parseCommandLineArgs(['--version'], 'test usage')).rejects.toThrow('process.exit:0')
+
+    // Then the version should be written before URL validation
+    expect(stdoutSpy).toHaveBeenCalledWith(expect.stringMatching(/^\d+\.\d+\.\d+\n$/))
+
+    stdoutSpy.mockRestore()
+    exitSpy.mockRestore()
+  })
+
   it('Scenario: Parse basic server URL', async () => {
     // Given command line arguments with only a server URL
     const args = ['https://example.com/sse']

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -735,6 +735,16 @@ export async function findAvailablePort(preferredPort?: number): Promise<number>
  * @returns A promise that resolves to an object with parsed serverUrl, callbackPort and headers
  */
 export async function parseCommandLineArgs(args: string[], usage: string) {
+  if (args.includes('--help') || args.includes('-h')) {
+    process.stdout.write(`${usage}\n`)
+    process.exit(0)
+  }
+
+  if (args.includes('--version') || args.includes('-v')) {
+    process.stdout.write(`${MCP_REMOTE_VERSION}\n`)
+    process.exit(0)
+  }
+
   // Process headers
   const headers: Record<string, string> = {}
   let i = 0

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -165,7 +165,7 @@ to the CA certificate file. If using claude_desktop_config.json, this might look
 }
 
 // Parse command-line arguments and run the proxy
-parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://server-url> [callback-port] [--debug]')
+parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote <https://server-url> [callback-port] [--debug]')
   .then(
     ({
       serverUrl,


### PR DESCRIPTION
## What changed
- Handle `--help` / `-h` before trying to parse the first argument as a server URL.
- Handle `--version` / `-v` before URL parsing.
- Update the proxy/client usage strings to show the published binary names.
- Add regression coverage for help/version early exits.

## Why
Published `mcp-remote@0.1.38` currently treats metadata flags as the required server URL. Commands such as `mcp-remote --help` and `mcp-remote --version` fail with `TypeError: Invalid URL` before users can inspect CLI usage or the installed version.

## Validation
- `npx --yes pnpm@10.11.0 test:unit`
- `npx --yes pnpm@10.11.0 check`
- `npx --yes pnpm@10.11.0 build`
- `node dist/proxy.js --help`
- `node dist/proxy.js --version`
- `node dist/client.js --help`
- `node dist/client.js --version`
- `git diff --check`