### PR TITLE
fix: add root package entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
   "tsup": {
     "entry": [
       "src/client.ts",
-      "src/proxy.ts"
+      "src/proxy.ts",
+      "src/index.ts"
     ],
     "format": [
       "esm"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,3 @@
+export { runProxy } from './proxy'
+export { connectToRemoteServer, mcpProxy, parseCommandLineArgs } from './lib/utils'
+export type { TransportStrategy } from './lib/utils'

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -10,6 +10,7 @@
  */
 
 import { EventEmitter } from 'events'
+import { pathToFileURL } from 'url'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
 import {
   connectToRemoteServer,
@@ -28,7 +29,7 @@ import { createLazyAuthCoordinator } from './lib/coordination'
 /**
  * Main function to run the proxy
  */
-async function runProxy(
+export async function runProxy(
   serverUrl: string,
   callbackPort: number,
   headers: Record<string, string>,
@@ -164,9 +165,10 @@ to the CA certificate file. If using claude_desktop_config.json, this might look
   }
 }
 
-// Parse command-line arguments and run the proxy
-parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://server-url> [callback-port] [--debug]')
-  .then(
+// Parse command-line arguments and run the proxy only when invoked as the CLI.
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://server-url> [callback-port] [--debug]')
+    .then(
     ({
       serverUrl,
       callbackPort,
@@ -196,7 +198,8 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
       )
     },
   )
-  .catch((error) => {
-    log('Fatal error:', error)
-    process.exit(1)
-  })
+    .catch((error) => {
+      log('Fatal error:', error)
+      process.exit(1)
+    })
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -169,35 +169,35 @@ to the CA certificate file. If using claude_desktop_config.json, this might look
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://server-url> [callback-port] [--debug]')
     .then(
-    ({
-      serverUrl,
-      callbackPort,
-      headers,
-      transportStrategy,
-      host,
-      debug,
-      staticOAuthClientMetadata,
-      staticOAuthClientInfo,
-      authorizeResource,
-      ignoredTools,
-      authTimeoutMs,
-      serverUrlHash,
-    }) => {
-      return runProxy(
+      ({
         serverUrl,
         callbackPort,
         headers,
         transportStrategy,
         host,
+        debug,
         staticOAuthClientMetadata,
         staticOAuthClientInfo,
         authorizeResource,
         ignoredTools,
         authTimeoutMs,
         serverUrlHash,
-      )
-    },
-  )
+      }) => {
+        return runProxy(
+          serverUrl,
+          callbackPort,
+          headers,
+          transportStrategy,
+          host,
+          staticOAuthClientMetadata,
+          staticOAuthClientInfo,
+          authorizeResource,
+          ignoredTools,
+          authTimeoutMs,
+          serverUrlHash,
+        )
+      },
+    )
     .catch((error) => {
       log('Fatal error:', error)
       process.exit(1)


### PR DESCRIPTION
## Summary
- add `src/index.ts` as the root package entrypoint so `main: dist/index.js` is emitted
- export `runProxy` and selected utility APIs without executing the CLI on import
- guard CLI startup so `import('mcp-remote')` does not parse argv or start the proxy

## Validation
- `corepack pnpm install --frozen-lockfile`
- `corepack pnpm build`
- `node --input-type=module -e "import('./dist/index.js').then(m=>{ if(!m.runProxy) throw new Error('runProxy missing'); console.log('mcp-remote dist index import ok') })"`

Related bounty: charles-openclaw/charles-microbounties#631