### PR TITLE
Build root package entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "LICENSE"
   ],
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "bin": {
     "mcp-remote": "dist/proxy.js",
     "mcp-remote-client": "dist/client.js"
@@ -50,6 +51,7 @@
   },
   "tsup": {
     "entry": [
+      "src/index.ts",
       "src/client.ts",
       "src/proxy.ts"
     ],

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,25 @@
+export { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
+export { createLazyAuthCoordinator, coordinateAuth, isLockValid, isPidRunning, waitForAuthentication } from './lib/coordination'
+export type { AuthCoordinator } from './lib/coordination'
+export {
+  connectToRemoteServer,
+  createMessageTransformer,
+  debugLog,
+  discoverOAuthServerInfo,
+  findAvailablePort,
+  getServerUrlHash,
+  log,
+  mcpProxy,
+  REASON_AUTH_NEEDED,
+  REASON_TRANSPORT_FALLBACK,
+  setupOAuthCallbackServer,
+  setupOAuthCallbackServerWithLongPoll,
+  shouldIncludeTool,
+} from './lib/utils'
+export type { AuthInitializer, OAuthServerDiscoveryResult, TransportStrategy } from './lib/utils'
+export type {
+  OAuthCallbackServerOptions,
+  OAuthProviderOptions,
+  StaticOAuthClientInformationFull,
+  StaticOAuthClientMetadata,
+} from './lib/types'


### PR DESCRIPTION
## Summary
- add a side-effect-free `src/index.ts` root entrypoint
- include `src/index.ts` in the tsup entries so `dist/index.js` is published
- add `types` pointing at `dist/index.d.ts` for the root package entrypoint

## Verification
- `pnpm build`
- `node --input-type=module -e "await import('./dist/index.js')"`
- `node -e "require('./dist/index.js')"`
- `pnpm check`

This fixes the package manifest currently advertising `main: dist/index.js` without producing that file in the build output.