### PR TITLE
feat: support customization of the OAuth callback path

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,17 @@ Some authorization servers reject the resource parameter outright — Microsoft 
       ]
 ```
 
+* To change the path `mcp-remote` serves the OAuth callback on (by default `/oauth/callback`), add the `--callback-path` flag. The path must start with `/`, and `/wait-for-auth` is reserved.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--callback-path",
+        "/custom/callback"
+      ]
+```
+
 * To allow HTTP connections in trusted private networks, add the `--allow-http` flag. Note: This should only be used in secure private networks where traffic cannot be intercepted.
 
 ```json

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,6 +31,7 @@ import { createLazyAuthCoordinator } from './lib/coordination'
  */
 async function runClient(
   serverUrl: string,
+  callbackPath: string,
   callbackPort: number,
   specifiedPort: number | undefined,
   headers: Record<string, string>,
@@ -49,7 +50,7 @@ async function runClient(
   const strictPort = !!specifiedPort || !!staticOAuthClientInfo
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, strictPort)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPath, callbackPort, events, authTimeoutMs, strictPort)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -70,6 +71,7 @@ async function runClient(
   // Create the OAuth client provider with discovered server info
   const authProvider = new NodeOAuthClientProvider({
     serverUrl: discoveryResult.authorizationServerUrl,
+    callbackPath,
     callbackPort,
     host,
     clientName: 'MCP CLI Client',
@@ -199,6 +201,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote-client <https://s
   .then(
     ({
       serverUrl,
+      callbackPath,
       callbackPort,
       specifiedPort,
       headers,
@@ -213,6 +216,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote-client <https://s
     }) => {
       return runClient(
         serverUrl,
+        callbackPath,
         callbackPort,
         specifiedPort,
         headers,

--- a/src/client.ts
+++ b/src/client.ts
@@ -31,6 +31,7 @@ import { createLazyAuthCoordinator } from './lib/coordination'
  */
 async function runClient(
   serverUrl: string,
+  callbackPath: string,
   callbackPort: number,
   headers: Record<string, string>,
   transportStrategy: TransportStrategy = 'http-first',
@@ -44,7 +45,7 @@ async function runClient(
   const events = new EventEmitter()
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPath, callbackPort, events, authTimeoutMs)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -182,6 +183,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
   .then(
     ({
       serverUrl,
+      callbackPath,
       callbackPort,
       headers,
       transportStrategy,
@@ -193,6 +195,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx client.ts <https://s
     }) => {
       return runClient(
         serverUrl,
+        callbackPath,
         callbackPort,
         headers,
         transportStrategy,

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -130,6 +130,7 @@ export async function waitForAuthentication(port: number): Promise<boolean> {
  */
 export function createLazyAuthCoordinator(
   serverUrlHash: string,
+  callbackPath: string,
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
@@ -148,7 +149,7 @@ export function createLazyAuthCoordinator(
       debugLog('Initializing auth coordination on-demand', { serverUrlHash, callbackPort })
 
       // Initialize auth using the existing coordinateAuth logic
-      authState = await coordinateAuth(serverUrlHash, callbackPort, events, authTimeoutMs)
+      authState = await coordinateAuth(serverUrlHash, callbackPath, callbackPort, events, authTimeoutMs)
       debugLog('Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth })
       return authState
     },
@@ -164,11 +165,12 @@ export function createLazyAuthCoordinator(
  */
 export async function coordinateAuth(
   serverUrlHash: string,
+  callbackPath: string,
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
 ): Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
-  debugLog('Coordinating authentication', { serverUrlHash, callbackPort })
+  debugLog('Coordinating authentication', { serverUrlHash, callbackPath, callbackPort })
 
   // Check for a lockfile (disabled on Windows for the time being)
   const lockData = process.platform === 'win32' ? null : await checkLockfile(serverUrlHash)
@@ -229,7 +231,7 @@ export async function coordinateAuth(
   debugLog('Setting up OAuth callback server', { port: callbackPort })
   const { server, waitForAuthCode, authCompletedPromise } = setupOAuthCallbackServerWithLongPoll({
     port: callbackPort,
-    path: '/oauth/callback',
+    path: callbackPath,
     events,
     authTimeoutMs,
   })

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -124,6 +124,7 @@ export async function waitForAuthentication(port: number): Promise<boolean> {
 /**
  * Creates a lazy auth coordinator that will only initiate auth when needed
  * @param serverUrlHash The hash of the server URL
+ * @param callbackPath The path to serve the callback endpoint on
  * @param callbackPort The port to use for the callback server
  * @param events The event emitter to use for signaling
  * @param strictPort If true, fail rather than fall back to a random port on EADDRINUSE
@@ -131,6 +132,7 @@ export async function waitForAuthentication(port: number): Promise<boolean> {
  */
 export function createLazyAuthCoordinator(
   serverUrlHash: string,
+  callbackPath: string,
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
@@ -150,7 +152,7 @@ export function createLazyAuthCoordinator(
       debugLog('Initializing auth coordination on-demand', { serverUrlHash, callbackPort })
 
       // Initialize auth using the existing coordinateAuth logic
-      authState = await coordinateAuth(serverUrlHash, callbackPort, events, authTimeoutMs, strictPort)
+      authState = await coordinateAuth(serverUrlHash, callbackPath, callbackPort, events, authTimeoutMs, strictPort)
       debugLog('Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth, actualPort: authState.actualPort })
       return authState
     },
@@ -160,6 +162,7 @@ export function createLazyAuthCoordinator(
 /**
  * Coordinates authentication between multiple instances of the client/proxy
  * @param serverUrlHash The hash of the server URL
+ * @param callbackPath The path to serve the callback endpoint on
  * @param callbackPort The port to use for the callback server
  * @param events The event emitter to use for signaling
  * @param strictPort If true, fail rather than fall back to a random port on EADDRINUSE
@@ -167,12 +170,13 @@ export function createLazyAuthCoordinator(
  */
 export async function coordinateAuth(
   serverUrlHash: string,
+  callbackPath: string,
   callbackPort: number,
   events: EventEmitter,
   authTimeoutMs: number,
   strictPort = false,
 ): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
-  debugLog('Coordinating authentication', { serverUrlHash, callbackPort })
+  debugLog('Coordinating authentication', { serverUrlHash, callbackPath, callbackPort })
 
   // Check for a lockfile (disabled on Windows for the time being)
   const lockData = process.platform === 'win32' ? null : await checkLockfile(serverUrlHash)
@@ -238,7 +242,7 @@ export async function coordinateAuth(
   debugLog('Setting up OAuth callback server', { port: callbackPort })
   const { server, actualPort, waitForAuthCode } = await setupOAuthCallbackServerWithLongPoll({
     port: callbackPort,
-    path: '/oauth/callback',
+    path: callbackPath,
     events,
     authTimeoutMs,
     strictPort,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -20,6 +20,20 @@ describe('Feature: Command Line Arguments Parsing', () => {
     expect(typeof result.serverUrl).toBe('string')
   })
 
+
+  it('Scenario: Parse server URL with callback path', async () => {
+    // Given command line arguments with server URL and port
+    const args = ['https://example.com/sse', '--callback-path', '/custom-callback']
+    const usage = 'test usage'
+
+    // When parsing the command line arguments
+    const result = await parseCommandLineArgs(args, usage)
+
+    // Then both server URL and callback path should be correctly extracted
+    expect(result.serverUrl).toBe('https://example.com/sse')
+    expect(result.callbackPath).toBe('/custom-callback')
+  })
+
   it('Scenario: Parse server URL with callback port', async () => {
     // Given command line arguments with server URL and port
     const args = ['https://example.com/sse', '3000']

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -79,6 +79,51 @@ describe('Feature: Command Line Arguments Parsing', () => {
     expect(result.callbackPort).toBe(3000)
   })
 
+  it('Scenario: Default to the standard callback path when --callback-path is absent', async () => {
+    // Given command line arguments without a callback path
+    const args = ['https://example.com/sse']
+
+    // When parsing the command line arguments
+    const result = await parseCommandLineArgs(args, 'test usage')
+
+    // Then the standard callback path should be used
+    expect(result.callbackPath).toBe('/oauth/callback')
+  })
+
+  it('Scenario: Parse server URL with callback path', async () => {
+    // Given command line arguments with a custom callback path
+    const args = ['https://example.com/sse', '--callback-path', '/custom-callback']
+
+    // When parsing the command line arguments
+    const result = await parseCommandLineArgs(args, 'test usage')
+
+    // Then both server URL and callback path should be correctly extracted
+    expect(result.serverUrl).toBe('https://example.com/sse')
+    expect(result.callbackPath).toBe('/custom-callback')
+  })
+
+  it('Scenario: Ignore a callback path that is not rooted', async () => {
+    // Given a callback path Express cannot route back to the redirect URI we would advertise
+    const args = ['https://example.com/sse', '--callback-path', 'custom-callback']
+
+    // When parsing the command line arguments
+    const result = await parseCommandLineArgs(args, 'test usage')
+
+    // Then the standard callback path should be kept
+    expect(result.callbackPath).toBe('/oauth/callback')
+  })
+
+  it('Scenario: Ignore a callback path that shadows the long-poll endpoint', async () => {
+    // Given a callback path that collides with the endpoint secondary instances poll
+    const args = ['https://example.com/sse', '--callback-path', '/wait-for-auth']
+
+    // When parsing the command line arguments
+    const result = await parseCommandLineArgs(args, 'test usage')
+
+    // Then the standard callback path should be kept
+    expect(result.callbackPath).toBe('/oauth/callback')
+  })
+
   it('Scenario: Parse localhost URL with HTTP protocol', async () => {
     // Given command line arguments with localhost HTTP URL
     const args = ['http://localhost:8080/sse']
@@ -1575,6 +1620,25 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
     } finally {
       await new Promise<void>((resolve) => blocker.close(() => resolve()))
     }
+  })
+
+  it('should serve the callback on the configured path', async () => {
+    const result = await setupOAuthCallbackServerWithLongPoll({
+      port: 0,
+      path: '/custom/callback',
+      events,
+    })
+
+    server = result.server
+
+    const response = await fetch(`http://127.0.0.1:${result.actualPort}/custom/callback?code=test-code`)
+    expect(response.status).toBe(200)
+    await expect(result.waitForAuthCode()).resolves.toBe('test-code')
+
+    // The default path must not be served when it was overridden, otherwise the redirect URI
+    // we advertise and the endpoint we listen on can silently disagree
+    const defaultPath = await fetch(`http://127.0.0.1:${result.actualPort}/oauth/callback?code=test-code`)
+    expect(defaultPath.status).toBe(404)
   })
 
   it('should reject with EADDRINUSE error when strictPort is true and port is already in use', async () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -889,6 +889,14 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
 
   const defaultPort = calculateDefaultPort(serverUrlHash)
 
+  // Parse callback path
+  let callbackPath = '';
+  const callbackPathIndex = args.indexOf('--callback-path')
+  if (callbackPathIndex !== -1 && callbackPathIndex < args.length - 1) {
+    callbackPath = args[callbackPathIndex + 1]
+    log(`Using callback path: ${callbackPath}`)
+  }
+
   // Use the specified port, or the existing client port or fallback to find an available one
   const [existingClientPort, availablePort] = await Promise.all([findExistingClientPort(serverUrlHash), findAvailablePort(defaultPort)])
   let callbackPort: number
@@ -931,6 +939,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
 
   return {
     serverUrl,
+    callbackPath,
     callbackPort,
     headers,
     transportStrategy,

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -750,7 +750,7 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   })
 
   // Long-polling endpoint
-  app.get('/wait-for-auth', (req, res) => {
+  app.get(LONG_POLL_PATH, (req, res) => {
     if (authCode) {
       // Auth already completed - just return 200 without the actual code
       // Secondary instances will read tokens from disk
@@ -880,8 +880,11 @@ export async function setupOAuthCallbackServer(options: OAuthCallbackServerOptio
   return { server, authCode, waitForAuthCode }
 }
 
-/** The callback path the OAuth redirect URI is built on. */
+/** The callback path the OAuth redirect URI is built on, unless --callback-path overrides it. */
 export const DEFAULT_CALLBACK_PATH = '/oauth/callback'
+
+/** Endpoint secondary instances long-poll to await the auth flow the primary instance is running. */
+export const LONG_POLL_PATH = '/wait-for-auth'
 
 /**
  * Builds the OAuth redirect URI for a given host/port. Kept in one place because the value
@@ -1049,6 +1052,23 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     log(`Using callback hostname: ${host}`)
   }
 
+  // Parse callback path. It has to be a path Express can route and that does not shadow the
+  // long-poll endpoint the coordination protocol between concurrent instances relies on,
+  // otherwise the authorization server redirects back to an endpoint that never resolves.
+  let callbackPath = DEFAULT_CALLBACK_PATH
+  const callbackPathIndex = args.indexOf('--callback-path')
+  if (callbackPathIndex !== -1 && callbackPathIndex < args.length - 1) {
+    const value = args[callbackPathIndex + 1]
+    if (!value.startsWith('/')) {
+      log(`Warning: Ignoring invalid callback path: ${value}. It must start with '/'.`)
+    } else if (value === LONG_POLL_PATH) {
+      log(`Warning: Ignoring reserved callback path: ${value}. It is used to coordinate concurrent instances.`)
+    } else {
+      callbackPath = value
+      log(`Using callback path: ${callbackPath}`)
+    }
+  }
+
   let staticOAuthClientMetadata: StaticOAuthClientMetadata = null
   const staticOAuthClientMetadataIndex = args.indexOf('--static-oauth-client-metadata')
   if (staticOAuthClientMetadataIndex !== -1 && staticOAuthClientMetadataIndex < args.length - 1) {
@@ -1185,7 +1205,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
   //
   // Static client info is pinned by the user, so it is never discarded.
   if (!staticOAuthClientInfo) {
-    await invalidateMismatchedClientRegistration(serverUrlHash, buildRedirectUrl(host, callbackPort))
+    await invalidateMismatchedClientRegistration(serverUrlHash, buildRedirectUrl(host, callbackPort, callbackPath))
   }
 
   if (Object.keys(headers).length > 0) {
@@ -1211,6 +1231,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
 
   return {
     serverUrl,
+    callbackPath,
     callbackPort,
     specifiedPort,
     headers,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -30,6 +30,7 @@ import { createLazyAuthCoordinator } from './lib/coordination'
  */
 async function runProxy(
   serverUrl: string,
+  callbackPath: string,
   callbackPort: number,
   specifiedPort: number | undefined,
   headers: Record<string, string>,
@@ -49,7 +50,7 @@ async function runProxy(
   const strictPort = !!specifiedPort || !!staticOAuthClientInfo
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs, strictPort)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPath, callbackPort, events, authTimeoutMs, strictPort)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -70,6 +71,7 @@ async function runProxy(
   // Create the OAuth client provider with discovered server info
   const authProvider = new NodeOAuthClientProvider({
     serverUrl: discoveryResult.authorizationServerUrl,
+    callbackPath,
     callbackPort,
     host,
     clientName: 'MCP CLI Proxy',
@@ -184,6 +186,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote <https://server-u
   .then(
     ({
       serverUrl,
+      callbackPath,
       callbackPort,
       specifiedPort,
       headers,
@@ -200,6 +203,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote <https://server-u
     }) => {
       return runProxy(
         serverUrl,
+        callbackPath,
         callbackPort,
         specifiedPort,
         headers,

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -30,6 +30,7 @@ import { createLazyAuthCoordinator } from './lib/coordination'
  */
 async function runProxy(
   serverUrl: string,
+  callbackPath: string,
   callbackPort: number,
   headers: Record<string, string>,
   transportStrategy: TransportStrategy = 'http-first',
@@ -45,7 +46,7 @@ async function runProxy(
   const events = new EventEmitter()
 
   // Create a lazy auth coordinator
-  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPort, events, authTimeoutMs)
+  const authCoordinator = createLazyAuthCoordinator(serverUrlHash, callbackPath, callbackPort, events, authTimeoutMs)
 
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
@@ -66,6 +67,7 @@ async function runProxy(
   // Create the OAuth client provider with discovered server info
   const authProvider = new NodeOAuthClientProvider({
     serverUrl: discoveryResult.authorizationServerUrl,
+    callbackPath,
     callbackPort,
     host,
     clientName: 'MCP CLI Proxy',
@@ -169,6 +171,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
   .then(
     ({
       serverUrl,
+      callbackPath,
       callbackPort,
       headers,
       transportStrategy,
@@ -183,6 +186,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: npx tsx proxy.ts <https://se
     }) => {
       return runProxy(
         serverUrl,
+        callbackPath,
         callbackPort,
         headers,
         transportStrategy,


### PR DESCRIPTION
This implements #75 with a new `--callback-path` CLI option to customize the OAuth callback endpoint.

There was already some support for customizing the callback in the `NodeOAuthClientProvider` and enabling this was mainly just a mattter of parsing the option from the CLI arguments.