### PR TITLE
Fix OAuth token exchange in proxy mode (finishAuth on the wrong transport)

### DIFF
--- a/src/lib/connect-to-remote-server.test.ts
+++ b/src/lib/connect-to-remote-server.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Shared state for the mocked SDK transports/clients. `vi.hoisted` lets the `vi.mock`
+// factories (which are hoisted above imports) reference this safely.
+const mockState = vi.hoisted(() => ({
+  // Every StreamableHTTPClientTransport constructed, in order.
+  httpTransports: [] as Array<{ start: ReturnType<typeof vi.fn>; finishAuth: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> }>,
+  // Number of remaining `Client.connect` calls that should fail with an auth error.
+  connectFailuresRemaining: 1,
+}))
+
+vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => {
+  class StreamableHTTPError extends Error {
+    code?: number
+    constructor(message: string, code?: number) {
+      super(message)
+      this.code = code
+    }
+  }
+  class StreamableHTTPClientTransport {
+    start = vi.fn().mockResolvedValue(undefined)
+    finishAuth = vi.fn().mockResolvedValue(undefined)
+    close = vi.fn().mockResolvedValue(undefined)
+    constructor(
+      public url: URL,
+      public opts: unknown,
+    ) {
+      mockState.httpTransports.push(this)
+    }
+  }
+  return { StreamableHTTPClientTransport, StreamableHTTPError }
+})
+
+vi.mock('@modelcontextprotocol/sdk/client/sse.js', () => {
+  class SSEClientTransport {
+    start = vi.fn().mockResolvedValue(undefined)
+    finishAuth = vi.fn().mockResolvedValue(undefined)
+    close = vi.fn().mockResolvedValue(undefined)
+    constructor(
+      public url: URL,
+      public opts: unknown,
+    ) {}
+  }
+  return { SSEClientTransport }
+})
+
+vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
+  class Client {
+    constructor(
+      public info: unknown,
+      public caps: unknown,
+    ) {}
+    async connect() {
+      // The one-off "fallback test" client is what actually probes the server. Simulate the
+      // server answering that probe with a 401, so the *test* transport is the one that receives
+      // (and stores) the challenge — exactly as happens in real proxy mode.
+      if (mockState.connectFailuresRemaining > 0) {
+        mockState.connectFailuresRemaining--
+        throw new Error('Unauthorized')
+      }
+    }
+  }
+  return { Client }
+})
+
+// Import after mocks are registered.
+import { connectToRemoteServer } from './utils'
+
+describe('connectToRemoteServer', () => {
+  beforeEach(() => {
+    mockState.httpTransports.length = 0
+    mockState.connectFailuresRemaining = 1
+    // Keep test output quiet; connectToRemoteServer logs to stderr.
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('completes auth on the transport that received the 401 challenge in proxy mode (regression: #270)', async () => {
+    const authInitializer = vi.fn().mockResolvedValue({
+      waitForAuthCode: async () => 'auth-code-123',
+      skipBrowserAuth: false,
+    })
+
+    // Proxy mode passes `client = null`, which drives the throwaway test-transport probe path.
+    await connectToRemoteServer(null, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')
+
+    // Instances, in construction order:
+    //   [0] first attempt's main transport   (never sees the 401)
+    //   [1] first attempt's test transport    (receives the 401 -> stores resource_metadata)
+    //   [2] second attempt's main transport   (connects successfully after auth)
+    //   [3] second attempt's test transport
+    const [mainTransport, testTransport] = mockState.httpTransports
+    expect(mockState.httpTransports.length).toBeGreaterThanOrEqual(2)
+
+    // The fix: finishAuth must run on the transport that actually handled the challenge,
+    // so the stored resource_metadata URL drives token_endpoint discovery.
+    expect(testTransport.finishAuth).toHaveBeenCalledTimes(1)
+    expect(testTransport.finishAuth).toHaveBeenCalledWith('auth-code-123')
+
+    // Regression guard: it must NOT be called on the main transport (which never saw the 401).
+    expect(mainTransport.finishAuth).not.toHaveBeenCalled()
+  })
+
+  it('completes auth on the main transport in with-client mode (parity with the working standalone client path)', async () => {
+    const authInitializer = vi.fn().mockResolvedValue({
+      waitForAuthCode: async () => 'auth-code-456',
+      skipBrowserAuth: false,
+    })
+
+    // The standalone `mcp-remote-client` binary passes a real Client, so `client.connect(transport)`
+    // sends the request through the *main* transport, which receives the 401 itself. This path
+    // already works (per #270); this test guards against regressing it. The first connect attempt
+    // fails with an auth error (the 401), the retry after auth succeeds.
+    let clientConnectCalls = 0
+    const client = {
+      connect: async () => {
+        if (clientConnectCalls++ === 0) throw new Error('Unauthorized')
+      },
+    } as any
+
+    await connectToRemoteServer(client, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')
+
+    // No throwaway test transport is created in with-client mode, so the first (and only auth-time)
+    // transport is the main one, and finishAuth must run on it.
+    const [mainTransport] = mockState.httpTransports
+    expect(mainTransport.finishAuth).toHaveBeenCalledTimes(1)
+    expect(mainTransport.finishAuth).toHaveBeenCalledWith('auth-code-456')
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -436,6 +436,16 @@ export async function connectToRemoteServer(
         requestInit: { headers },
       })
 
+  // When connecting without a Client (proxy mode), the auth challenge (401) is not received by
+  // `transport` itself but by the one-off `testTransport` created below. The SDK stores the
+  // `resource_metadata` URL from the WWW-Authenticate header on the transport that received the
+  // 401, and `finishAuth` reads it back to discover the authorization server. If we call
+  // `finishAuth` on `transport` (which never saw the 401) that URL is missing, so the token
+  // exchange falls back to POSTing at the resource origin instead of the discovered
+  // `token_endpoint` (see https://github.com/geelen/mcp-remote/issues/270). Track the transport
+  // that actually handled the challenge so we can complete auth on it.
+  let authChallengeTransport: SSEClientTransport | StreamableHTTPClientTransport | undefined
+
   try {
     debugLog('Attempting to connect to remote server', { sseTransport })
 
@@ -452,6 +462,8 @@ export async function connectToRemoteServer(
         // out if we're actually talking to an HTTP server or not.
         debugLog('Creating test transport for HTTP-only connection test')
         const testTransport = new StreamableHTTPClientTransport(url, { authProvider, requestInit: { headers } })
+        // This transport is the one that will receive (and store the metadata from) any 401 challenge.
+        authChallengeTransport = testTransport
         const testClient = new Client({ name: 'mcp-remote-fallback-test', version: '0.0.0' }, { capabilities: {} })
         await testClient.connect(testTransport)
       }
@@ -524,7 +536,10 @@ export async function connectToRemoteServer(
 
       try {
         log('Completing authorization...')
-        await transport.finishAuth(code)
+        // Complete auth on the transport that received the 401 challenge (in proxy mode this is the
+        // one-off test transport, not `transport`), so the stored resource_metadata URL is used to
+        // discover the correct token_endpoint. Falls back to `transport` for the with-client path.
+        await (authChallengeTransport ?? transport).finishAuth(code)
         debugLog('Authorization completed successfully')
 
         if (recursionReasons.has(REASON_AUTH_NEEDED)) {


### PR DESCRIPTION
## Summary

Fixes the OAuth failure reported in #270: in proxy mode (`npx mcp-remote <url>`, e.g. from Claude Desktop), the authorization-code exchange is POSTed to the **resource URL** instead of the `token_endpoint` from the discovered authorization-server metadata, so login fails with an HTTP 404 out of `executeTokenRequest`.

## Root cause

`connectToRemoteServer` (`src/lib/utils.ts`) is called with a real `Client` in client mode (`client.ts`) but with `client = null` in proxy mode (`proxy.ts`), and those two paths differ in *which transport receives the 401 challenge*:

- **With a client** — `client.connect(transport)` sends `initialize` through the **main transport**, so it receives the 401 and the SDK stores the `resource_metadata` URL (from the `WWW-Authenticate` header) on it. `finishAuth` then runs on that same transport and discovers the correct `token_endpoint`. ✅
- **Without a client** (proxy mode) — the code calls `transport.start()`, which sends **no** request (so the main transport never sees a 401), then creates a one-off `testTransport` to probe whether the server speaks HTTP. That `testTransport` receives the 401 and stores the `resource_metadata` URL — but `finishAuth` was still called on the **main `transport`**, which never saw the challenge. With no `resource_metadata` URL, the SDK's token-exchange discovery falls back to POSTing at the resource origin (`<resource-origin>/token`) instead of the real `token_endpoint`. ❌

This is exactly why #270 observed that the standalone `mcp-remote-client` binary succeeds while proxy mode fails against the *same* server.

## Fix

Track the transport that actually handled the auth challenge and complete auth on it:

```ts
let authChallengeTransport: SSEClientTransport | StreamableHTTPClientTransport | undefined
// ...
authChallengeTransport = testTransport
// ...
await (authChallengeTransport ?? transport).finishAuth(code)
```

The `?? transport` fallback keeps the with-client path (and SSE) unchanged, so it's a no-op there.

## Tests

Adds `src/lib/connect-to-remote-server.test.ts`:

- **proxy mode** → `finishAuth` runs on the challenge (test) transport, not the main one — this assertion fails on the current code and passes with the fix.
- **with-client mode** → `finishAuth` runs on the main transport (parity / regression guard).

`pnpm test:unit` (all existing + new), `pnpm check` (prettier + tsc), and `pnpm build` are green. I also verified end-to-end with the built proxy against a server whose Protected Resource Metadata is only reachable via the `WWW-Authenticate` `resource_metadata` hint (Microsoft Entra ID as the authorization server): the handshake now completes ("Proxy established successfully"), where stock 0.1.35–0.1.38 all 404'd at the token exchange.

## Not in scope: #301

#301 (authorize URL built from the server origin) is a related but distinct symptom and is intentionally left out; this PR is scoped to the token-exchange path in #270.

---

@acitatorq — since you filed #270 with that very precise "standalone client works but proxy fails" detail (which was the key to isolating this), would you be willing to review and confirm it resolves the issue against your Okta setup? 🙏

*Diagnosed and implemented with the help of Claude (Claude Code).*

Closes #270
