### PR TITLE
fix: surface failed request forwards as JSON-RPC errors instead of hanging

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -979,6 +979,100 @@ describe('Feature: MCP Proxy', () => {
       }),
     )
   })
+
+  it('Scenario: Failed forward of a request surfaces a JSON-RPC error to the client', async () => {
+    // Given a server transport whose send() rejects, e.g. because the
+    // server expired the session and answers HTTP 404 (issue #106)
+    const mockTransportToClient = {
+      send: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      onmessage: vi.fn(),
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+    } as unknown as Transport
+
+    const mockTransportToServer = {
+      send: vi.fn().mockRejectedValue(new Error('Error POSTing to endpoint (HTTP 404): Session not found')),
+      close: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      onmessage: vi.fn(),
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+    } as unknown as Transport
+
+    mcpProxy({
+      transportToClient: mockTransportToClient,
+      transportToServer: mockTransportToServer,
+      ignoredTools: [],
+    })
+
+    // When the client sends a request (a message with an id)
+    const clientRequest = {
+      jsonrpc: '2.0' as const,
+      method: 'tools/call',
+      id: 42,
+      params: { name: 'SomeTool', arguments: {} },
+    }
+    if (mockTransportToClient.onmessage) {
+      mockTransportToClient.onmessage(clientRequest)
+    }
+
+    // Then the client receives a JSON-RPC error response for that id
+    // instead of waiting forever for a reply that never arrives
+    await vi.waitFor(() => {
+      expect(mockTransportToClient.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          jsonrpc: '2.0',
+          id: 42,
+          error: expect.objectContaining({
+            code: -32603,
+            message: expect.stringContaining('HTTP 404'),
+          }),
+        }),
+      )
+    })
+  })
+
+  it('Scenario: Failed forward of a notification does not produce a response', async () => {
+    // Given a server transport whose send() rejects
+    const mockTransportToClient = {
+      send: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      onmessage: vi.fn(),
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+    } as unknown as Transport
+
+    const mockTransportToServer = {
+      send: vi.fn().mockRejectedValue(new Error('Error POSTing to endpoint (HTTP 404): Session not found')),
+      close: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      onmessage: vi.fn(),
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+    } as unknown as Transport
+
+    mcpProxy({
+      transportToClient: mockTransportToClient,
+      transportToServer: mockTransportToServer,
+      ignoredTools: [],
+    })
+
+    // When the client sends a notification (no id)
+    const clientNotification = {
+      jsonrpc: '2.0' as const,
+      method: 'notifications/initialized',
+    }
+    if (mockTransportToClient.onmessage) {
+      mockTransportToClient.onmessage(clientNotification)
+    }
+
+    // Then no response is sent back — JSON-RPC forbids replies to notifications
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(mockTransportToClient.send).not.toHaveBeenCalled()
+  })
 })
 
 describe('setupOAuthCallbackServerWithLongPoll', () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -201,7 +201,26 @@ export function mcpProxy({
       debugLog('Initialize message with modified client info', { clientInfo })
     }
 
-    transportToServer.send(message).catch(onServerError)
+    transportToServer.send(message).catch((error) => {
+      onServerError(error)
+
+      // If forwarding a request fails, the local client would wait forever
+      // for a response that never arrives (e.g. the server expired the
+      // session and answers 404, see #106). Surface the failure as a
+      // JSON-RPC error response instead. Notifications carry no id and
+      // must not be answered.
+      if (message.id !== undefined && message.id !== null) {
+        const errorResponse = {
+          jsonrpc: '2.0' as const,
+          id: message.id,
+          error: {
+            code: -32603,
+            message: `Failed to forward message to remote server: ${error instanceof Error ? error.message : String(error)}`,
+          },
+        }
+        transportToClient.send(errorResponse).catch(onClientError)
+      }
+    })
   }
 
   transportToServer.onmessage = (_message) => {


### PR DESCRIPTION
## Problem

Fixes the "hang" part of #106.

When `transportToServer.send()` rejects while forwarding a client request, the error is only logged:

```ts
transportToServer.send(message).catch(onServerError)
```

The local client keeps waiting for a response to its request id that will never arrive — from the host's perspective (Claude Code, Cursor, …) the tool call hangs indefinitely. We debugged this in production against a TYPO3 MCP server: the server answered a spec-conform **HTTP 404** for an expired session (`Mcp-Session-Id` unknown), mcp-remote logged `Error POSTing to endpoint (HTTP 404)` — and the host waited 30 minutes into its idle timeout.

## Change

If forwarding a **request** (message with an `id`) fails, send a JSON-RPC error response for that id back to the local client, mirroring the pattern already used for blocked tools in `interceptRequest`. Hosts then fail fast and can reconnect. Failed **notifications** (no `id`) are still not answered, as JSON-RPC forbids responses to them.

This intentionally does not implement the full spec behaviour for 404 ("client MUST start a new session by sending a new InitializeRequest") — that needs replaying the cached initialize params and is better done as a follow-up. Surfacing the error at least turns a silent forever-hang into an actionable failure.

## Tests

Two new scenarios in `utils.test.ts` (55/55 passing): a rejected request forward produces a JSON-RPC error response with the original id; a rejected notification forward produces no response. `prettier --check` and `tsc` are clean.