### PR TITLE
fix: preserve MCP method metadata in HTTP transport

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
   connectToRemoteServer,
+  encodeMcpHeaderValue,
   parseCommandLineArgs,
   shouldIncludeTool,
   mcpProxy,
@@ -575,74 +576,226 @@ describe('Feature: Command Line Arguments Parsing', () => {
   })
 })
 
-describe('Feature: Method-aware MCP HTTP gateways', () => {
-  it('mirrors the JSON-RPC method in the Mcp-Method header', async () => {
-    const requests: Array<{ method: string; header: string | undefined }> = []
-    const server = createServer((request, response) => {
-      if (request.method !== 'POST') {
-        response.writeHead(405)
+/**
+ * A minimal MCP endpoint that records the standard request headers it is sent.
+ *
+ * Only enough of the protocol is implemented to get a client through `initialize`
+ * and a single `tools/call`.
+ */
+function createHeaderRecordingServer() {
+  const seen: Array<{ method: string; mcpMethod?: string; mcpName?: string }> = []
+
+  const first = (value: string | string[] | undefined) => (Array.isArray(value) ? value[0] : value)
+
+  const server = createServer((request, response) => {
+    if (request.method !== 'POST') {
+      response.writeHead(405)
+      response.end()
+      return
+    }
+
+    let body = ''
+    request.setEncoding('utf8')
+    request.on('data', (chunk: string) => {
+      body += chunk
+    })
+    request.on('end', () => {
+      const message = JSON.parse(body) as { id?: string | number; method: string; params?: { name?: string } }
+      seen.push({
+        method: message.method,
+        mcpMethod: first(request.headers['mcp-method']),
+        mcpName: first(request.headers['mcp-name']),
+      })
+
+      // Notifications get an empty 202, per the Streamable HTTP transport.
+      if (message.id === undefined) {
+        response.writeHead(202)
         response.end()
         return
       }
 
-      let body = ''
-      request.setEncoding('utf8')
-      request.on('data', (chunk: string) => {
-        body += chunk
-      })
-      request.on('end', () => {
-        const message = JSON.parse(body) as { id?: string | number; method: string }
-        const header = request.headers['mcp-method']
-        requests.push({ method: message.method, header: Array.isArray(header) ? header[0] : header })
-
-        if (message.id === undefined) {
-          response.writeHead(202)
-          response.end()
-          return
-        }
-
-        response.writeHead(200, { 'content-type': 'application/json' })
-        response.end(
-          JSON.stringify({
-            jsonrpc: '2.0',
-            id: message.id,
-            result: {
+      const result =
+        message.method === 'initialize'
+          ? {
               protocolVersion: '2025-03-26',
-              capabilities: {},
+              capabilities: { tools: {} },
               serverInfo: { name: 'test-server', version: '1.0.0' },
-            },
-          }),
-        )
+            }
+          : { content: [{ type: 'text', text: 'ok' }] }
+
+      response.writeHead(200, { 'content-type': 'application/json' })
+      response.end(JSON.stringify({ jsonrpc: '2.0', id: message.id, result }))
+    })
+  })
+
+  return {
+    seen,
+    async start() {
+      await new Promise<void>((resolve, reject) => {
+        server.once('error', reject)
+        server.listen(0, '127.0.0.1', resolve)
       })
-    })
-
-    await new Promise<void>((resolve, reject) => {
-      server.once('error', reject)
-      server.listen(0, '127.0.0.1', resolve)
-    })
-
-    try {
       const address = server.address()
       if (!address || typeof address === 'string') throw new Error('test server did not expose a port')
+      return `http://127.0.0.1:${address.port}/mcp`
+    },
+    async stop() {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    },
+  }
+}
 
+const noAuth = async () => {
+  throw new Error('the test server should not request OAuth')
+}
+
+describe('Feature: Method-aware MCP HTTP gateways', () => {
+  it('Scenario: The JSON-RPC method is mirrored into Mcp-Method', async () => {
+    // Given a server that records the headers it receives
+    const gateway = createHeaderRecordingServer()
+    const url = await gateway.start()
+
+    try {
+      // When a client connects and sends a further message
+      const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+      const transport = await connectToRemoteServer(client, url, undefined as unknown as OAuthClientProvider, {}, noAuth, 'http-only')
+
+      await transport.send({ jsonrpc: '2.0', method: 'server/discover', params: {} })
+
+      // Then every POST carries the method it is actually sending
+      expect(gateway.seen[0]).toMatchObject({ method: 'initialize', mcpMethod: 'initialize' })
+      expect(gateway.seen).toContainEqual(expect.objectContaining({ method: 'server/discover', mcpMethod: 'server/discover' }))
+      await transport.close()
+    } finally {
+      await gateway.stop()
+    }
+  })
+
+  it('Scenario: tools/call also carries the tool name in Mcp-Name', async () => {
+    // Given a server that records the headers it receives
+    const gateway = createHeaderRecordingServer()
+    const url = await gateway.start()
+
+    try {
+      // When the client calls a tool
+      const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+      const transport = await connectToRemoteServer(client, url, undefined as unknown as OAuthClientProvider, {}, noAuth, 'http-only')
+      await client.callTool({ name: 'get_weather', arguments: { location: 'Seattle, WA' } })
+
+      // Then the call is routable on both headers without parsing the body.
+      // Sending Mcp-Method alone here would itself be a -32020 HeaderMismatch.
+      expect(gateway.seen).toContainEqual({ method: 'tools/call', mcpMethod: 'tools/call', mcpName: 'get_weather' })
+
+      // And a method that has no Mcp-Name source does not invent one
+      expect(gateway.seen[0]).toEqual({ method: 'initialize', mcpMethod: 'initialize', mcpName: undefined })
+      await transport.close()
+    } finally {
+      await gateway.stop()
+    }
+  })
+
+  it('Scenario: resources/read sources Mcp-Name from params.uri', async () => {
+    // Given a server that records the headers it receives
+    const gateway = createHeaderRecordingServer()
+    const url = await gateway.start()
+
+    try {
+      const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+      const transport = await connectToRemoteServer(client, url, undefined as unknown as OAuthClientProvider, {}, noAuth, 'http-only')
+
+      // When a resources/read and a prompts/get go out
+      await transport.send({ jsonrpc: '2.0', method: 'resources/read', params: { uri: 'file:///app/config.json' } })
+      await transport.send({ jsonrpc: '2.0', method: 'prompts/get', params: { name: 'summarize' } })
+      // A URI RFC 9110 cannot carry verbatim has to survive the trip encoded
+      await transport.send({ jsonrpc: '2.0', method: 'resources/read', params: { uri: 'file:///projects/世界.json' } })
+
+      // Then each takes its name from the field SEP-2243 assigns it
+      expect(gateway.seen).toContainEqual({
+        method: 'resources/read',
+        mcpMethod: 'resources/read',
+        mcpName: 'file:///app/config.json',
+      })
+      expect(gateway.seen).toContainEqual({ method: 'prompts/get', mcpMethod: 'prompts/get', mcpName: 'summarize' })
+      expect(gateway.seen).toContainEqual({
+        method: 'resources/read',
+        mcpMethod: 'resources/read',
+        mcpName: encodeMcpHeaderValue('file:///projects/世界.json'),
+      })
+      await transport.close()
+    } finally {
+      await gateway.stop()
+    }
+  })
+
+  it('Scenario: An explicitly passed header is not overwritten', async () => {
+    // Given a server that records the headers it receives
+    const gateway = createHeaderRecordingServer()
+    const url = await gateway.start()
+
+    try {
+      // When the user pins Mcp-Method themselves via --header
       const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
       const transport = await connectToRemoteServer(
         client,
-        `http://127.0.0.1:${address.port}/mcp`,
+        url,
         undefined as unknown as OAuthClientProvider,
-        {},
-        async () => {
-          throw new Error('the test server should not request OAuth')
-        },
+        { 'Mcp-Method': 'pinned-by-user' },
+        noAuth,
         'http-only',
       )
 
-      expect(requests[0]).toEqual({ method: 'initialize', header: 'initialize' })
-      await transport.send({ jsonrpc: '2.0', method: 'server/discover', params: {} })
-      expect(requests).toContainEqual({ method: 'server/discover', header: 'server/discover' })
+      // Then their value survives
+      expect(gateway.seen[0]).toMatchObject({ method: 'initialize', mcpMethod: 'pinned-by-user' })
       await transport.close()
     } finally {
-      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+      await gateway.stop()
+    }
+  })
+
+  it('Scenario: The http-first probe carries the headers too', async () => {
+    // Given a server that records the headers it receives
+    const gateway = createHeaderRecordingServer()
+    const url = await gateway.start()
+
+    try {
+      // When connecting in proxy mode (client=null), where a one-off probe transport
+      // sends the first initialize
+      const transport = await connectToRemoteServer(null, url, undefined as unknown as OAuthClientProvider, {}, noAuth, 'http-first')
+
+      // Then the probe - the very request a method-aware gateway routes on - is labelled
+      expect(gateway.seen[0]).toMatchObject({ method: 'initialize', mcpMethod: 'initialize' })
+      await transport.close()
+    } finally {
+      await gateway.stop()
+    }
+  })
+})
+
+describe('Feature: Encoding MCP header values', () => {
+  it('Scenario: Plain ASCII values are sent as-is', () => {
+    expect(encodeMcpHeaderValue('get_weather')).toBe('get_weather')
+    expect(encodeMcpHeaderValue('file:///projects/myapp/config.json')).toBe('file:///projects/myapp/config.json')
+  })
+
+  it('Scenario: Values RFC 9110 cannot carry are Base64 encoded', () => {
+    // Non-ASCII
+    expect(encodeMcpHeaderValue('Hello, 世界')).toBe('=?base64?SGVsbG8sIOS4lueVjA==?=')
+    // Leading/trailing whitespace
+    expect(encodeMcpHeaderValue(' padded ')).toBe('=?base64?IHBhZGRlZCA=?=')
+    // Embedded newline - the header-injection case
+    expect(encodeMcpHeaderValue('line1\nline2')).toBe('=?base64?bGluZTEKbGluZTI=?=')
+  })
+
+  it('Scenario: A literal that looks like the sentinel is itself encoded', () => {
+    // Otherwise a server would decode a value that was never encoded
+    expect(encodeMcpHeaderValue('=?base64?literal?=')).toBe('=?base64?PT9iYXNlNjQ/bGl0ZXJhbD89?=')
+  })
+
+  it('Scenario: Encoded values round-trip back to the body value', () => {
+    for (const original of ['Hello, 世界', ' padded ', 'line1\nline2', '=?base64?literal?=']) {
+      const encoded = encodeMcpHeaderValue(original)
+      const decoded = Buffer.from(encoded.slice('=?base64?'.length, -'?='.length), 'base64').toString('utf8')
+      expect(decoded).toBe(original)
     }
   })
 })

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { parseCommandLineArgs, shouldIncludeTool, mcpProxy, setupOAuthCallbackServerWithLongPoll, getServerUrlHash } from './utils'
+import {
+  connectToRemoteServer,
+  getServerUrlHash,
+  mcpProxy,
+  parseCommandLineArgs,
+  setupOAuthCallbackServerWithLongPoll,
+  shouldIncludeTool,
+} from './utils'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
 import { EventEmitter } from 'events'
 import express from 'express'
+import { createServer } from 'node:http'
 
 // All sanitizeUrl tests have been moved to the strict-url-sanitise package
 
@@ -430,6 +440,78 @@ describe('Feature: Command Line Arguments Parsing', () => {
     expect(consoleSpy).not.toHaveBeenCalled()
 
     consoleSpy.mockRestore()
+  })
+})
+
+describe('Feature: Method-aware MCP HTTP gateways', () => {
+  it('mirrors the JSON-RPC method in the Mcp-Method header', async () => {
+    const requests: Array<{ method: string; header: string | undefined }> = []
+    const server = createServer((request, response) => {
+      if (request.method !== 'POST') {
+        response.writeHead(405)
+        response.end()
+        return
+      }
+
+      let body = ''
+      request.setEncoding('utf8')
+      request.on('data', (chunk: string) => {
+        body += chunk
+      })
+      request.on('end', () => {
+        const message = JSON.parse(body) as { id?: string | number; method: string }
+        const header = request.headers['mcp-method']
+        requests.push({ method: message.method, header: Array.isArray(header) ? header[0] : header })
+
+        if (message.id === undefined) {
+          response.writeHead(202)
+          response.end()
+          return
+        }
+
+        response.writeHead(200, { 'content-type': 'application/json' })
+        response.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              protocolVersion: '2025-03-26',
+              capabilities: {},
+              serverInfo: { name: 'test-server', version: '1.0.0' },
+            },
+          }),
+        )
+      })
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('test server did not expose a port')
+
+      const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+      const transport = await connectToRemoteServer(
+        client,
+        `http://127.0.0.1:${address.port}/mcp`,
+        undefined as unknown as OAuthClientProvider,
+        {},
+        async () => {
+          throw new Error('the test server should not request OAuth')
+        },
+        'http-only',
+      )
+
+      expect(requests[0]).toEqual({ method: 'initialize', header: 'initialize' })
+      await transport.send({ jsonrpc: '2.0', method: 'server/discover', params: {} })
+      expect(requests).toContainEqual({ method: 'server/discover', header: 'server/discover' })
+      await transport.close()
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
   })
 })
 

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import {
+  connectToRemoteServer,
   parseCommandLineArgs,
   shouldIncludeTool,
   mcpProxy,
@@ -10,8 +11,11 @@ import {
 } from './utils'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import type { OAuthClientProvider } from '@modelcontextprotocol/sdk/client/auth.js'
 import { EventEmitter } from 'events'
 import express from 'express'
+import { createServer } from 'node:http'
 import net from 'net'
 import fs from 'fs'
 import os from 'os'
@@ -568,6 +572,78 @@ describe('Feature: Command Line Arguments Parsing', () => {
     expect(consoleSpy).not.toHaveBeenCalled()
 
     consoleSpy.mockRestore()
+  })
+})
+
+describe('Feature: Method-aware MCP HTTP gateways', () => {
+  it('mirrors the JSON-RPC method in the Mcp-Method header', async () => {
+    const requests: Array<{ method: string; header: string | undefined }> = []
+    const server = createServer((request, response) => {
+      if (request.method !== 'POST') {
+        response.writeHead(405)
+        response.end()
+        return
+      }
+
+      let body = ''
+      request.setEncoding('utf8')
+      request.on('data', (chunk: string) => {
+        body += chunk
+      })
+      request.on('end', () => {
+        const message = JSON.parse(body) as { id?: string | number; method: string }
+        const header = request.headers['mcp-method']
+        requests.push({ method: message.method, header: Array.isArray(header) ? header[0] : header })
+
+        if (message.id === undefined) {
+          response.writeHead(202)
+          response.end()
+          return
+        }
+
+        response.writeHead(200, { 'content-type': 'application/json' })
+        response.end(
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              protocolVersion: '2025-03-26',
+              capabilities: {},
+              serverInfo: { name: 'test-server', version: '1.0.0' },
+            },
+          }),
+        )
+      })
+    })
+
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(0, '127.0.0.1', resolve)
+    })
+
+    try {
+      const address = server.address()
+      if (!address || typeof address === 'string') throw new Error('test server did not expose a port')
+
+      const client = new Client({ name: 'test-client', version: '1.0.0' }, { capabilities: {} })
+      const transport = await connectToRemoteServer(
+        client,
+        `http://127.0.0.1:${address.port}/mcp`,
+        undefined as unknown as OAuthClientProvider,
+        {},
+        async () => {
+          throw new Error('the test server should not request OAuth')
+        },
+        'http-only',
+      )
+
+      expect(requests[0]).toEqual({ method: 'initialize', header: 'initialize' })
+      await transport.send({ jsonrpc: '2.0', method: 'server/discover', params: {} })
+      expect(requests).toContainEqual({ method: 'server/discover', header: 'server/discover' })
+      await transport.close()
+    } finally {
+      await new Promise<void>((resolve, reject) => server.close((error) => (error ? reject(error) : resolve())))
+    }
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,6 +3,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { OAuthClientInformationFull, OAuthClientInformationFullSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { AuthCodeResult, OAuthCallbackServerOptions, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './types'
@@ -32,6 +33,40 @@ declare global {
 // Connection constants
 export const REASON_AUTH_NEEDED = 'authentication-needed'
 export const REASON_TRANSPORT_FALLBACK = 'falling-back-to-alternate-transport'
+
+/**
+ * Extract the JSON-RPC method from a request body for method-aware HTTP gateways.
+ *
+ * Some MCP gateways route or validate POST requests using the `Mcp-Method` header
+ * in addition to the JSON-RPC body. The SDK does not add that extension header,
+ * so mcp-remote must derive it at the transport boundary.
+ */
+function mcpMethodFromBody(body: RequestInit['body']): string | undefined {
+  if (typeof body !== 'string') return undefined
+
+  try {
+    const message: unknown = JSON.parse(body)
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return undefined
+
+    const method = (message as { method?: unknown }).method
+    return typeof method === 'string' && method.length > 0 ? method : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Add the method-aware MCP header without replacing caller-supplied headers.
+ */
+const fetchWithMcpMethod = async (url: string | URL, init?: RequestInit) => {
+  const method = mcpMethodFromBody(init?.body)
+  if (!method) return fetch(url, init)
+
+  const headers = new Headers(init?.headers)
+  if (!headers.has('Mcp-Method')) headers.set('Mcp-Method', method)
+
+  return fetch(url, { ...init, headers })
+}
 
 // Transport strategy types
 export type TransportStrategy = 'sse-only' | 'http-only' | 'sse-first' | 'http-first'
@@ -580,10 +615,12 @@ export async function connectToRemoteServer(
         authProvider,
         requestInit: { headers },
         eventSourceInit,
+        fetch: fetchWithMcpMethod as unknown as FetchLike,
       })
     : new StreamableHTTPClientTransport(url, {
         authProvider,
         requestInit: { headers },
+        fetch: fetchWithMcpMethod as unknown as FetchLike,
       })
 
   // When connecting without a Client (proxy mode), the auth challenge (401) is not received by

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -3,6 +3,7 @@ import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { OAuthClientInformationFull, OAuthClientInformationFullSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { OAuthCallbackServerOptions, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './types'
@@ -31,6 +32,40 @@ declare global {
 // Connection constants
 export const REASON_AUTH_NEEDED = 'authentication-needed'
 export const REASON_TRANSPORT_FALLBACK = 'falling-back-to-alternate-transport'
+
+/**
+ * Extract the JSON-RPC method from a request body for method-aware HTTP gateways.
+ *
+ * Some MCP gateways route or validate POST requests using the `Mcp-Method` header
+ * in addition to the JSON-RPC body. The SDK does not add that extension header,
+ * so mcp-remote must derive it at the transport boundary.
+ */
+function mcpMethodFromBody(body: RequestInit['body']): string | undefined {
+  if (typeof body !== 'string') return undefined
+
+  try {
+    const message: unknown = JSON.parse(body)
+    if (!message || typeof message !== 'object' || Array.isArray(message)) return undefined
+
+    const method = (message as { method?: unknown }).method
+    return typeof method === 'string' && method.length > 0 ? method : undefined
+  } catch {
+    return undefined
+  }
+}
+
+/**
+ * Add the method-aware MCP header without replacing caller-supplied headers.
+ */
+const fetchWithMcpMethod = async (url: string | URL, init?: RequestInit) => {
+  const method = mcpMethodFromBody(init?.body)
+  if (!method) return fetch(url, init)
+
+  const headers = new Headers(init?.headers)
+  if (!headers.has('Mcp-Method')) headers.set('Mcp-Method', method)
+
+  return fetch(url, { ...init, headers })
+}
 
 // Transport strategy types
 export type TransportStrategy = 'sse-only' | 'http-only' | 'sse-first' | 'http-first'
@@ -430,10 +465,12 @@ export async function connectToRemoteServer(
         authProvider,
         requestInit: { headers },
         eventSourceInit,
+        fetch: fetchWithMcpMethod as unknown as FetchLike,
       })
     : new StreamableHTTPClientTransport(url, {
         authProvider,
         requestInit: { headers },
+        fetch: fetchWithMcpMethod as unknown as FetchLike,
       })
 
   try {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2,8 +2,7 @@ import { OAuthClientProvider, UnauthorizedError } from '@modelcontextprotocol/sd
 import { Client } from '@modelcontextprotocol/sdk/client/index.js'
 import { SSEClientTransport } from '@modelcontextprotocol/sdk/client/sse.js'
 import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
-import type { FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { Transport, type FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { OAuthClientInformationFull, OAuthClientInformationFullSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { AuthCodeResult, OAuthCallbackServerOptions, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './types'
@@ -35,38 +34,93 @@ export const REASON_AUTH_NEEDED = 'authentication-needed'
 export const REASON_TRANSPORT_FALLBACK = 'falling-back-to-alternate-transport'
 
 /**
- * Extract the JSON-RPC method from a request body for method-aware HTTP gateways.
+ * Which JSON-RPC methods carry an `Mcp-Name`, and where its value comes from.
  *
- * Some MCP gateways route or validate POST requests using the `Mcp-Method` header
- * in addition to the JSON-RPC body. The SDK does not add that extension header,
- * so mcp-remote must derive it at the transport boundary.
+ * SEP-2243 sources the header from `params.name` for tools and prompts, and from
+ * `params.uri` for resources.
  */
-function mcpMethodFromBody(body: RequestInit['body']): string | undefined {
+const MCP_NAME_SOURCES: Record<string, 'name' | 'uri'> = {
+  'tools/call': 'name',
+  'prompts/get': 'name',
+  'resources/read': 'uri',
+}
+
+type MirroredMcpHeaders = { method: string; name?: string }
+
+/**
+ * Read the standard MCP request headers out of a JSON-RPC body.
+ *
+ * A batch body is deliberately skipped: it has no single method to mirror, and
+ * mirroring one of several is worse than sending nothing.
+ */
+function mcpHeadersFromBody(body: RequestInit['body']): MirroredMcpHeaders | undefined {
   if (typeof body !== 'string') return undefined
 
+  let message: unknown
   try {
-    const message: unknown = JSON.parse(body)
-    if (!message || typeof message !== 'object' || Array.isArray(message)) return undefined
-
-    const method = (message as { method?: unknown }).method
-    return typeof method === 'string' && method.length > 0 ? method : undefined
+    message = JSON.parse(body)
   } catch {
     return undefined
   }
+
+  if (!message || typeof message !== 'object' || Array.isArray(message)) return undefined
+
+  const { method, params } = message as { method?: unknown; params?: unknown }
+  if (typeof method !== 'string' || method.length === 0) return undefined
+
+  const source = MCP_NAME_SOURCES[method]
+  if (!source || !params || typeof params !== 'object') return { method }
+
+  const name = (params as Record<string, unknown>)[source]
+  return typeof name === 'string' && name.length > 0 ? { method, name } : { method }
 }
 
 /**
- * Add the method-aware MCP header without replacing caller-supplied headers.
+ * Encode a header value per the SEP-2243 value rules.
+ *
+ * RFC 9110 field values are visible ASCII plus space and tab, with no leading or
+ * trailing whitespace. Anything outside that - and any literal that would itself
+ * be mistaken for the sentinel - travels Base64.
  */
-const fetchWithMcpMethod = async (url: string | URL, init?: RequestInit) => {
-  const method = mcpMethodFromBody(init?.body)
-  if (!method) return fetch(url, init)
+export function encodeMcpHeaderValue(value: string): string {
+  const headerSafe = /^[\x21-\x7e](?:[\x20-\x7e\t]*[\x21-\x7e])?$/.test(value)
+  const looksEncoded = value.startsWith('=?base64?') && value.endsWith('?=')
+
+  return headerSafe && !looksEncoded ? value : `=?base64?${Buffer.from(value, 'utf8').toString('base64')}?=`
+}
+
+/**
+ * Mirror the JSON-RPC method and target into the standard MCP request headers.
+ *
+ * SEP-2243 (spec revision 2026-07-28) requires `Mcp-Method` on every request and
+ * `Mcp-Name` on `tools/call`, `resources/read` and `prompts/get`, so that gateways
+ * can route and meter without parsing the body. The SDK sends neither, which is
+ * what strands mcp-remote behind a method-aware gateway (#306).
+ *
+ * Both are derived from the exact body being sent, never from anything else: a
+ * server that enforces the rule rejects a header that disagrees with the body -
+ * or a required one that is missing - with `-32020 HeaderMismatch`. That is also
+ * why `Mcp-Method` is never sent alone for a method that requires `Mcp-Name`;
+ * a partial set is itself a mismatch.
+ *
+ * Caller-supplied headers win, so an explicit `--header` still overrides.
+ *
+ * The cast bridges types only: this module is undici-typed throughout (see the
+ * import above) while `FetchLike` is declared against the global DOM types. They
+ * are the same implementation at runtime on the Node versions we support.
+ */
+const fetchWithMcpHeaders = (async (url: string | URL, init?: RequestInit) => {
+  const mirrored = mcpHeadersFromBody(init?.body)
+  if (!mirrored) return fetch(url, init)
 
   const headers = new Headers(init?.headers)
-  if (!headers.has('Mcp-Method')) headers.set('Mcp-Method', method)
+  if (!headers.has('Mcp-Method')) headers.set('Mcp-Method', mirrored.method)
+  if (mirrored.name !== undefined && !headers.has('Mcp-Name')) {
+    headers.set('Mcp-Name', encodeMcpHeaderValue(mirrored.name))
+  }
 
   return fetch(url, { ...init, headers })
-}
+}) as unknown as FetchLike
 
 // Transport strategy types
 export type TransportStrategy = 'sse-only' | 'http-only' | 'sse-first' | 'http-first'
@@ -615,12 +669,12 @@ export async function connectToRemoteServer(
         authProvider,
         requestInit: { headers },
         eventSourceInit,
-        fetch: fetchWithMcpMethod as unknown as FetchLike,
+        fetch: fetchWithMcpHeaders,
       })
     : new StreamableHTTPClientTransport(url, {
         authProvider,
         requestInit: { headers },
-        fetch: fetchWithMcpMethod as unknown as FetchLike,
+        fetch: fetchWithMcpHeaders,
       })
 
   // When connecting without a Client (proxy mode), the auth challenge (401) is not received by
@@ -648,7 +702,14 @@ export async function connectToRemoteServer(
         // the client is already connected. So let's just create a one-off client to make a single request and figure
         // out if we're actually talking to an HTTP server or not.
         debugLog('Creating test transport for HTTP-only connection test')
-        const testTransport = new StreamableHTTPClientTransport(url, { authProvider, requestInit: { headers } })
+        // This probe sends the very first `initialize` POST, so it is the request a
+        // method-aware gateway routes on. It needs the mirrored headers as much as the
+        // real transport does.
+        const testTransport = new StreamableHTTPClientTransport(url, {
+          authProvider,
+          requestInit: { headers },
+          fetch: fetchWithMcpHeaders,
+        })
         // This transport is the one that will receive (and store the metadata from) any 401 challenge.
         authChallengeTransport = testTransport
         const testClient = new Client({ name: 'mcp-remote-fallback-test', version: '0.0.0' }, { capabilities: {} })


### PR DESCRIPTION
## Summary

Some MCP gateways need the request method metadata that newer MCP clients provide. This adds an SDK fetch wrapper that preserves existing headers and injects `Mcp-Method` from JSON-RPC request bodies when absent.

## Validation

- added a local method-aware HTTP gateway regression test
- `pnpm test:unit`
- `pnpm check`
- `pnpm build`