### PR TITLE
Fix PKCE code_verifier corruption when multiple mcp-remote instances race

### DIFF
--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -17,8 +17,12 @@ import { log, MCP_REMOTE_VERSION } from './utils'
  *   - Format: OAuthClientInformation object with client_id and other registration details
  * - {server_hash}_tokens.json: Contains OAuth access and refresh tokens
  *   - Format: OAuthTokens object with access_token, refresh_token, and expiration information
- * - {server_hash}_code_verifier.txt: Contains the PKCE code verifier for the current OAuth flow
+ * - {server_hash}_code_verifier_{pid}.txt: Contains the PKCE code verifier for the current OAuth flow
  *   - Format: Plain text string used for PKCE verification
+ *   - Scoped per-process (by PID) rather than per-server: multiple mcp-remote processes can be
+ *     started concurrently for the same server, and coordination between them is currently
+ *     disabled on Windows (see coordination.ts), so a shared filename would let one process's
+ *     verifier silently overwrite another's mid-flow (see issue #235)
  *
  * All JSON files are stored with 2-space indentation for readability.
  */

--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -161,6 +161,56 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
     })
   })
 
+  // Regression tests for https://github.com/geelen/mcp-remote/issues/235:
+  // concurrent mcp-remote processes for the same server used to share a single
+  // code_verifier.txt file, so a second process starting mid-flow would silently
+  // overwrite the first process's verifier and break its PKCE token exchange.
+  describe('PKCE code verifier isolation across processes', () => {
+    let mockReadTextFile: any
+    let mockWriteTextFile: any
+
+    beforeEach(() => {
+      mockReadTextFile = vi.mocked(mcpAuthConfig.readTextFile)
+      mockWriteTextFile = vi.mocked(mcpAuthConfig.writeTextFile)
+      mockWriteTextFile.mockResolvedValue(undefined)
+      mockReadTextFile.mockResolvedValue('test-verifier')
+    })
+
+    it('should save the code verifier to a filename scoped to the current process ID', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      await provider.saveCodeVerifier('test-verifier')
+
+      expect(mockWriteTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`, 'test-verifier')
+      // Two processes for the same server must never target the same filename
+      expect(mockWriteTextFile).not.toHaveBeenCalledWith('test-hash', 'code_verifier.txt', 'test-verifier')
+    })
+
+    it('should read the code verifier back from the same process-scoped filename', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      await provider.codeVerifier()
+
+      expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`, expect.any(String))
+    })
+
+    it('should delete the process-scoped verifier file when invalidating the verifier scope', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      await provider.invalidateCredentials('verifier')
+
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`)
+    })
+
+    it('should delete the process-scoped verifier file when invalidating all credentials', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      await provider.invalidateCredentials('all')
+
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`)
+    })
+  })
+
   describe('scopes_supported parsing', () => {
     it('should use custom scopes without filtering', () => {
       const metadata: AuthorizationServerMetadata = {

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -281,11 +281,20 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
   /**
    * Saves the PKCE code verifier
+   *
+   * The filename is scoped to the current process ID. Multiple mcp-remote
+   * processes can be started concurrently for the same server (e.g. an MCP
+   * host reconnecting or launching duplicate instances) - since coordination
+   * between those processes is currently disabled on Windows (see
+   * coordination.ts), each process must keep its own verifier so a second
+   * process can't overwrite the first one's file mid-flow and break the
+   * PKCE exchange for whichever process the browser callback actually
+   * reaches. See https://github.com/geelen/mcp-remote/issues/235.
    * @param codeVerifier The code verifier to save
    */
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
     debugLog('Saving code verifier')
-    await writeTextFile(this.serverUrlHash, 'code_verifier.txt', codeVerifier)
+    await writeTextFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`, codeVerifier)
   }
 
   /**
@@ -294,7 +303,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    */
   async codeVerifier(): Promise<string> {
     debugLog('Reading code verifier')
-    const verifier = await readTextFile(this.serverUrlHash, 'code_verifier.txt', 'No code verifier saved for session')
+    const verifier = await readTextFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`, 'No code verifier saved for session')
     debugLog('Code verifier found:', !!verifier)
     return verifier
   }
@@ -311,7 +320,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
         await Promise.all([
           deleteConfigFile(this.serverUrlHash, 'client_info.json'),
           deleteConfigFile(this.serverUrlHash, 'tokens.json'),
-          deleteConfigFile(this.serverUrlHash, 'code_verifier.txt'),
+          deleteConfigFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`),
         ])
         this._clientInfo = undefined
         debugLog('All credentials invalidated')
@@ -329,7 +338,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
         break
 
       case 'verifier':
-        await deleteConfigFile(this.serverUrlHash, 'code_verifier.txt')
+        await deleteConfigFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`)
         debugLog('Code verifier invalidated')
         break
 


### PR DESCRIPTION
## Summary

Fixes #235 (and the same root cause reported in #251).

Concurrent `mcp-remote` processes for the same server share a single
`{serverUrlHash}_code_verifier.txt` file. Cross-process coordination via
the lockfile in `coordination.ts` is explicitly disabled on Windows:

```js
// Check for a lockfile (disabled on Windows for the time being)
const lockData = process.platform === 'win32' ? null : await checkLockfile(serverUrlHash)
```

and even on platforms where it's enabled, it only kicks in once a lockfile
already exists — it doesn't prevent two processes that start close together
from both reaching `startAuthorization()` and each calling `saveCodeVerifier()`
before either one has written a lockfile the other would see.

When that happens:

1. Process A generates verifier `V1`, saves it, and opens a browser tab
   built from challenge `C1 = hash(V1)`.
2. Process B (e.g. a duplicate instance spawned by the MCP host, or a
   reconnect attempt) generates verifier `V2` and overwrites the same file.
3. The user completes the login flow in process A's browser tab. The
   returned authorization code was issued for `C1`.
4. Process A's token exchange reads the verifier from disk — but it's now
   `V2` — and the authorization server rejects it: `invalid_grant: PKCE
   verification failed`.

This is timing-dependent, which matches both issues' reports of
intermittent failures ("worked once, then failed again").

I reproduced this directly: with the original code, running two `mcp-remote`
processes against the same server concurrently, the second process's
`code_verifier.txt` write clobbers the first's, and recomputing
`sha256(base64url(verifier_on_disk))` no longer matches the `code_challenge`
that was actually sent in the first process's authorize URL.

## Fix

Scope the code verifier file to the current process ID
(`{serverUrlHash}_code_verifier_{pid}.txt}`) instead of just the server URL
hash, so concurrent processes can never overwrite each other's PKCE state.
This is the fix suggested directly in #235's "Workaround" section.

I intentionally kept this scoped to just the verifier file and didn't touch
the Windows lockfile-disable in `coordination.ts` — that's a larger, riskier
change (the comment gives no reason for the disable, and I didn't want to
reintroduce whatever issue motivated it) and per-process verifier isolation
already fully resolves the corruption regardless of whether lockfile
coordination is active. With this fix, a "losing" concurrent process just
ends up with its own unused verifier file and its own (harmless, ignorable)
pending auth flow, rather than corrupting a process that's actually being
used to complete login.

## Test plan

- Added unit tests in `node-oauth-client-provider.test.ts` covering that
  `saveCodeVerifier`/`codeVerifier`/`invalidateCredentials('verifier'|'all')`
  all use the process-scoped filename.
- `pnpm test:unit` — all 107 tests pass.
- `pnpm run check` (prettier + tsc) passes on the changed files.
- Manually reproduced the race with two concurrent `mcp-remote` processes
  against a local OAuth server before and after the fix: before, the second
  process's verifier file overwrote the first's and the recomputed hash no
  longer matched the first process's advertised `code_challenge`; after,
  each process keeps its own file and its own verifier/challenge pair stays
  consistent throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)