### PR TITLE
Survive hosts that start and stop instances during the OAuth flow

### DIFF
--- a/src/lib/connect-to-remote-server.test.ts
+++ b/src/lib/connect-to-remote-server.test.ts
@@ -69,6 +69,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
 
 // Import after mocks are registered.
 import { connectToRemoteServer } from './utils'
+import type { AuthCodeResult } from './types'
 
 describe('connectToRemoteServer', () => {
   beforeEach(() => {
@@ -81,7 +82,7 @@ describe('connectToRemoteServer', () => {
 
   it('completes auth on the transport that received the 401 challenge in proxy mode (regression: #270)', async () => {
     const authInitializer = vi.fn().mockResolvedValue({
-      waitForAuthCode: async () => 'auth-code-123',
+      waitForAuthCode: async () => ({ code: 'auth-code-123' }),
       skipBrowserAuth: false,
     })
 
@@ -107,7 +108,7 @@ describe('connectToRemoteServer', () => {
 
   it('completes auth on the main transport in with-client mode (parity with the working standalone client path)', async () => {
     const authInitializer = vi.fn().mockResolvedValue({
-      waitForAuthCode: async () => 'auth-code-456',
+      waitForAuthCode: async () => ({ code: 'auth-code-456' }),
       skipBrowserAuth: false,
     })
 
@@ -134,7 +135,7 @@ describe('connectToRemoteServer', () => {
   // What `coordinateAuth` hands a secondary instance once a sibling has finished the browser flow:
   // there is no code to wait for, so awaiting one blocks until the MCP host times the server out.
   const secondaryInstanceAuth = () => ({
-    waitForAuthCode: vi.fn(() => new Promise<string>(() => {})),
+    waitForAuthCode: vi.fn(() => new Promise<AuthCodeResult>(() => {})),
     skipBrowserAuth: true,
   })
 
@@ -169,7 +170,7 @@ describe('connectToRemoteServer', () => {
   it('does not re-exchange a spent authorization code when the retry also fails (regression: #322)', async () => {
     // A real callback server retains the code it received, so a second call yields the same one
     const authInitializer = vi.fn().mockResolvedValue({
-      waitForAuthCode: async () => 'auth-code-789',
+      waitForAuthCode: async () => ({ code: 'auth-code-789' }),
       skipBrowserAuth: false,
     })
     mockState.connectFailuresRemaining = Number.MAX_SAFE_INTEGER

--- a/src/lib/coordination.test.ts
+++ b/src/lib/coordination.test.ts
@@ -1,42 +1,126 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
-import fs from 'fs/promises'
-import os from 'os'
+import { mkdtempSync, mkdirSync, rmSync, existsSync, writeFileSync } from 'fs'
+import { spawn } from 'child_process'
+import { tmpdir } from 'os'
 import path from 'path'
 import { writeJsonFile } from './mcp-auth-config'
-import { waitForTokensFromPrimary } from './coordination'
+import { MCP_REMOTE_VERSION } from './utils'
+
+const SERVER_HASH = 'testserverhash'
+
+let configDir: string
+
+/** Returns the pid of a process that has already exited, so liveness checks fail for it. */
+async function deadPid(): Promise<number> {
+  const child = spawn(process.execPath, ['-e', ''], { stdio: 'ignore' })
+  const pid = child.pid!
+  await new Promise((resolve) => child.once('exit', resolve))
+  return pid
+}
+
+/** Files live in the version subdirectory the config helpers append to the base dir. */
+function configFile(filename: string): string {
+  return path.join(configDir, `mcp-remote-${MCP_REMOTE_VERSION}`, `${SERVER_HASH}_${filename}`)
+}
+
+function lockPath(): string {
+  return configFile('lock.json')
+}
+
+beforeEach(() => {
+  configDir = mkdtempSync(path.join(tmpdir(), 'mcp-remote-coordination-'))
+  process.env.MCP_REMOTE_CONFIG_DIR = configDir
+  mkdirSync(path.join(configDir, `mcp-remote-${MCP_REMOTE_VERSION}`), { recursive: true })
+  // coordinateAuth logs to stderr; keep the test output readable
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+  vi.resetModules()
+})
+
+afterEach(() => {
+  delete process.env.MCP_REMOTE_CONFIG_DIR
+  rmSync(configDir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
 
 describe('Feature: Token handoff between concurrent instances', () => {
-  const hash = 'handoff-test'
-  let configDir: string
-
-  beforeEach(async () => {
-    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-remote-handoff-'))
-    process.env.MCP_REMOTE_CONFIG_DIR = configDir
-    // coordinateAuth logs to stderr; keep the test output readable
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-  })
-
-  afterEach(async () => {
-    delete process.env.MCP_REMOTE_CONFIG_DIR
-    await fs.rm(configDir, { recursive: true, force: true })
-  })
-
   it('Scenario: Resolves once the primary instance persists its tokens', async () => {
+    const { waitForTokensFromPrimary } = await import('./coordination')
     // Given tokens that are not on disk yet - the primary's callback fired, but the code has
     // not been exchanged. This is the window a fixed sleep used to gamble on.
-    const waiting = waitForTokensFromPrimary(hash, 5000)
+    const waiting = waitForTokensFromPrimary(SERVER_HASH, 5000)
 
     // When the primary finishes the exchange and writes them
     await new Promise((resolve) => setTimeout(resolve, 300))
-    await writeJsonFile(hash, 'tokens.json', { access_token: 'from-primary', token_type: 'Bearer' })
+    await writeJsonFile(SERVER_HASH, 'tokens.json', { access_token: 'from-primary', token_type: 'Bearer' })
 
     // Then the secondary stops waiting
     await expect(waiting).resolves.toBe(true)
   })
 
   it('Scenario: Gives up when the primary never writes them', async () => {
+    const { waitForTokensFromPrimary } = await import('./coordination')
     // Given a primary that signalled completion but never persisted anything
     // Then the secondary reports failure instead of blocking forever
-    await expect(waitForTokensFromPrimary(hash, 500)).resolves.toBe(false)
+    await expect(waitForTokensFromPrimary(SERVER_HASH, 500)).resolves.toBe(false)
+  })
+})
+
+describe('Feature: Lockfile ownership', () => {
+  it('Scenario: an exiting instance keeps a lockfile another instance owns', async () => {
+    const { deleteOwnLockfileSync } = await import('./coordination')
+    // process.ppid is alive and is not us, standing in for a concurrent instance
+    writeFileSync(lockPath(), JSON.stringify({ pid: process.ppid, port: 1234, timestamp: Date.now() }))
+
+    deleteOwnLockfileSync(SERVER_HASH)
+
+    expect(existsSync(lockPath())).toBe(true)
+  })
+
+  it('Scenario: an exiting instance removes its own lockfile', async () => {
+    const { deleteOwnLockfileSync } = await import('./coordination')
+    writeFileSync(lockPath(), JSON.stringify({ pid: process.pid, port: 1234, timestamp: Date.now() }))
+
+    deleteOwnLockfileSync(SERVER_HASH)
+
+    expect(existsSync(lockPath())).toBe(false)
+  })
+
+  it('Scenario: async cleanup keeps a lockfile another instance owns', async () => {
+    const { deleteOwnLockfile } = await import('./coordination')
+    writeFileSync(lockPath(), JSON.stringify({ pid: process.ppid, port: 1234, timestamp: Date.now() }))
+
+    await deleteOwnLockfile(SERVER_HASH)
+
+    expect(existsSync(lockPath())).toBe(true)
+  })
+})
+
+describe('Feature: Waiting on another instance', () => {
+  it('Scenario: waiting stops once the instance holding the lock is gone', async () => {
+    const { waitForAuthentication } = await import('./coordination')
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
+
+    const result = await waitForAuthentication(1234, { pid: await deadPid(), port: 1234, timestamp: Date.now() })
+
+    expect(result).toBe(false)
+  })
+
+  it('Scenario: waiting stops after an unreachable instance stays silent', async () => {
+    const { waitForAuthentication } = await import('./coordination')
+    vi.spyOn(globalThis, 'fetch').mockRejectedValue(new Error('ECONNREFUSED'))
+
+    // Owner is alive, so only the silence timeout can end the wait
+    const result = await waitForAuthentication(1234, { pid: process.ppid, port: 1234, timestamp: Date.now() })
+
+    expect(result).toBe(false)
+  }, 20000)
+
+  it('Scenario: waiting succeeds when the other instance completes authentication', async () => {
+    const { waitForAuthentication } = await import('./coordination')
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue({ status: 200 } as Response)
+
+    const result = await waitForAuthentication(1234, { pid: process.ppid, port: 1234, timestamp: Date.now() })
+
+    expect(result).toBe(true)
   })
 })

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -1,10 +1,11 @@
 import { checkLockfile, createLockfile, deleteLockfile, getConfigFilePath, readJsonFile, LockfileData } from './mcp-auth-config'
 import { OAuthTokensSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
+import { AuthCodeResult } from './types'
 import { EventEmitter } from 'events'
 import { Server } from 'http'
 import express from 'express'
 import { AddressInfo } from 'net'
-import { unlinkSync } from 'fs'
+import { readFileSync, unlinkSync } from 'fs'
 import { log, debugLog, setupOAuthCallbackServerWithLongPoll } from './utils'
 
 /** How long a secondary instance waits for the primary to persist the tokens it just obtained. */
@@ -12,7 +13,12 @@ const TOKEN_HANDOFF_TIMEOUT_MS = 30_000
 const TOKEN_HANDOFF_POLL_INTERVAL_MS = 200
 
 export type AuthCoordinator = {
-  initializeAuth: () => Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean; actualPort: number }>
+  initializeAuth: () => Promise<{
+    server: Server
+    waitForAuthCode: () => Promise<AuthCodeResult>
+    skipBrowserAuth: boolean
+    actualPort: number
+  }>
 }
 
 /**
@@ -80,16 +86,59 @@ export async function isLockValid(lockData: LockfileData): Promise<boolean> {
   }
 }
 
+/** How long to keep polling a sibling that stops answering before taking over. */
+const UNREACHABLE_SIBLING_TIMEOUT = 6000
+
+function readLockfileSync(serverUrlHash: string): LockfileData | null {
+  try {
+    return JSON.parse(readFileSync(getConfigFilePath(serverUrlHash, 'lock.json'), 'utf-8')) as LockfileData
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Deletes the lockfile, unless another instance owns it
+ *
+ * An exiting duplicate must not strip the lock from the instance driving the flow.
+ * @param serverUrlHash The hash of the server URL
+ */
+export async function deleteOwnLockfile(serverUrlHash: string): Promise<void> {
+  const lockData = readLockfileSync(serverUrlHash)
+  if (lockData && lockData.pid !== process.pid) {
+    debugLog('Leaving lockfile owned by another instance', { owner: lockData.pid, self: process.pid })
+    return
+  }
+  await deleteLockfile(serverUrlHash)
+}
+
+/**
+ * Synchronous counterpart of {@link deleteOwnLockfile}, for the 'exit' event
+ * @param serverUrlHash The hash of the server URL
+ */
+export function deleteOwnLockfileSync(serverUrlHash: string): void {
+  const lockData = readLockfileSync(serverUrlHash)
+  if (lockData && lockData.pid !== process.pid) {
+    debugLog('Leaving lockfile owned by another instance', { owner: lockData.pid, self: process.pid })
+    return
+  }
+  const configPath = getConfigFilePath(serverUrlHash, 'lock.json')
+  unlinkSync(configPath)
+  debugLog(`Removed lockfile on exit: ${configPath}`)
+}
+
 /**
  * Waits for authentication from another server instance
  * @param port The port to connect to
+ * @param lockData The lockfile entry describing the instance we are waiting on, when known
  * @returns True if authentication completed successfully, false otherwise
  */
-export async function waitForAuthentication(port: number): Promise<boolean> {
+export async function waitForAuthentication(port: number, lockData?: LockfileData): Promise<boolean> {
   log(`Waiting for authentication from the server on port ${port}...`)
 
   try {
     let attempts = 0
+    let unreachableSince: number | null = null
     while (true) {
       attempts++
       const url = `http://127.0.0.1:${port}/wait-for-auth`
@@ -99,6 +148,7 @@ export async function waitForAuthentication(port: number): Promise<boolean> {
       try {
         const response = await fetch(url)
         debugLog(`Poll response status: ${response.status}`)
+        unreachableSince = null
 
         if (response.status === 200) {
           // Auth completed, but we don't return the code anymore
@@ -115,6 +165,19 @@ export async function waitForAuthentication(port: number): Promise<boolean> {
         }
       } catch (fetchError) {
         debugLog(`Fetch error during poll`, fetchError)
+
+        // The instance holding the lock may have been killed mid-flow
+        if (lockData && !(await isPidRunning(lockData.pid))) {
+          log(`Instance holding the lock (pid ${lockData.pid}) is gone`)
+          return false
+        }
+        if (unreachableSince === null) {
+          unreachableSince = Date.now()
+        } else if (Date.now() - unreachableSince > UNREACHABLE_SIBLING_TIMEOUT) {
+          log(`Authentication server on port ${port} stopped responding`)
+          return false
+        }
+
         // If we can't connect, we'll try again after a delay
         await new Promise((resolve) => setTimeout(resolve, 2000))
       }
@@ -143,7 +206,8 @@ export function createLazyAuthCoordinator(
   authTimeoutMs: number,
   strictPort = false,
 ): AuthCoordinator {
-  let authState: { server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean; actualPort: number } | null = null
+  let authState: { server: Server; waitForAuthCode: () => Promise<AuthCodeResult>; skipBrowserAuth: boolean; actualPort: number } | null =
+    null
 
   return {
     initializeAuth: async () => {
@@ -210,7 +274,7 @@ export async function coordinateAuth(
   events: EventEmitter,
   authTimeoutMs: number,
   strictPort = false,
-): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
+): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<AuthCodeResult>; skipBrowserAuth: boolean }> {
   debugLog('Coordinating authentication', { serverUrlHash, callbackPath, callbackPort })
 
   // Check for a lockfile (disabled on Windows for the time being)
@@ -229,7 +293,7 @@ export async function coordinateAuth(
     try {
       // Try to wait for the authentication to complete
       debugLog('Waiting for authentication from other instance')
-      const authCompleted = await waitForAuthentication(lockData.port)
+      const authCompleted = await waitForAuthentication(lockData.port, lockData)
 
       // `waitForAuthentication` only reports that the primary's callback fired, which is strictly
       // earlier than its token exchange finishing, so wait for the tokens themselves. If they
@@ -300,7 +364,7 @@ export async function coordinateAuth(
   const cleanupHandler = async () => {
     try {
       log(`Cleaning up lockfile for server ${serverUrlHash}`)
-      await deleteLockfile(serverUrlHash)
+      await deleteOwnLockfile(serverUrlHash)
     } catch (error) {
       log(`Error cleaning up lockfile: ${error}`)
       debugLog('Error cleaning up lockfile', error)
@@ -310,9 +374,7 @@ export async function coordinateAuth(
   process.once('exit', () => {
     try {
       // Synchronous version for 'exit' event since we can't use async here
-      const configPath = getConfigFilePath(serverUrlHash, 'lock.json')
-      unlinkSync(configPath)
-      debugLog(`Removed lockfile on exit: ${configPath}`)
+      deleteOwnLockfileSync(serverUrlHash)
     } catch (error) {
       debugLog(`Error removing lockfile on exit:`, error)
     }

--- a/src/lib/mcp-auth-config.test.ts
+++ b/src/lib/mcp-auth-config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { writeJsonFile, readJsonFile, getConfigFilePath } from './mcp-auth-config'
+import { writeJsonFile, readJsonFile, getConfigFilePath, claimConfigFile, deleteStaleConfigFiles } from './mcp-auth-config'
 
 vi.mock('./utils', () => ({
   log: vi.fn(),
@@ -60,5 +60,54 @@ describe('Feature: Config file writes', () => {
     const stat = await fs.stat(target)
     // The temp file carries mode 0o600 through the rename
     expect(stat.mode & 0o777).toBe(0o600)
+  })
+})
+
+describe('Feature: Claiming a file exactly once', () => {
+  const hash = 'claim-test'
+  const filename = 'pending_auth.json'
+
+  afterEach(async () => {
+    await fs.unlink(getConfigFilePath(hash, filename)).catch(() => {})
+  })
+
+  it('Scenario: Only one of several concurrent instances wins the claim', async () => {
+    // Given three instances started together, as an MCP host does
+    const claims = await Promise.all([1, 2, 3].map((n) => claimConfigFile(hash, filename, { state: `instance-${n}` })))
+
+    // Then exactly one of them may act on it, and the file records that one
+    expect(claims.filter(Boolean)).toHaveLength(1)
+    const stored = await readJsonFile<{ state: string }>(hash, filename, { parseAsync: async (d: any) => d })
+    expect(stored?.state).toBe(`instance-${claims.indexOf(true) + 1}`)
+  })
+})
+
+describe('Feature: Sweeping files nothing will name again', () => {
+  const hash = 'sweep-test'
+  const prefix = 'code_verifier_'
+
+  const write = async (name: string, ageMs: number) => {
+    const target = getConfigFilePath(hash, name)
+    await writeJsonFile(hash, name, 'verifier')
+    const when = new Date(Date.now() - ageMs)
+    await fs.utimes(target, when, when)
+    return target
+  }
+
+  it('Scenario: Abandoned files go, files a live flow may still need stay', async () => {
+    // Given one verifier from a flow long abandoned and one from a flow still in progress
+    const abandoned = await write(`${prefix}old.txt`, 10 * 60 * 1000)
+    const inFlight = await write(`${prefix}fresh.txt`, 0)
+    const unrelated = await write('tokens.json', 10 * 60 * 1000)
+
+    await deleteStaleConfigFiles(hash, prefix, 3 * 60 * 1000)
+
+    await expect(fs.access(abandoned)).rejects.toThrow()
+    await expect(fs.access(inFlight)).resolves.toBeUndefined()
+    // The sweep is scoped to the prefix it was given
+    await expect(fs.access(unrelated)).resolves.toBeUndefined()
+
+    await fs.unlink(inFlight).catch(() => {})
+    await fs.unlink(unrelated).catch(() => {})
   })
 })

--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -223,6 +223,66 @@ export async function readTextFile(serverUrlHash: string, filename: string, erro
  * @param filename The name of the file to write
  * @param text The text to write
  */
+/**
+ * Creates a config file only if it does not exist yet, so concurrent instances racing for it
+ * agree on a single winner
+ * @param serverUrlHash The hash of the server URL
+ * @param filename The name of the file to create
+ * @param data The data to write
+ * @returns True if this call created the file
+ */
+export async function claimConfigFile(serverUrlHash: string, filename: string, data: any): Promise<boolean> {
+  await ensureConfigDir()
+  try {
+    await fs.writeFile(getConfigFilePath(serverUrlHash, filename), JSON.stringify(data, null, 2), {
+      encoding: 'utf-8',
+      mode: 0o600,
+      flag: 'wx',
+    })
+    return true
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === 'EEXIST') return false
+    log(`Error claiming ${filename}:`, error)
+    throw error
+  }
+}
+
+/**
+ * Removes this server's config files with the given prefix that are older than maxAgeMs
+ *
+ * Files named after a one-off flow are never named again, so abandoned ones accumulate. The age
+ * check leaves alone anything a concurrent instance may still be about to use.
+ * @param serverUrlHash The hash of the server URL
+ * @param prefix The filename prefix to sweep
+ * @param maxAgeMs How old a file must be before it is removed
+ */
+export async function deleteStaleConfigFiles(serverUrlHash: string, prefix: string, maxAgeMs: number): Promise<void> {
+  try {
+    const configDir = getConfigDir()
+    const entries = await fs.readdir(configDir)
+    const cutoff = Date.now() - maxAgeMs
+
+    await Promise.all(
+      entries
+        .filter((entry) => entry.startsWith(`${serverUrlHash}_${prefix}`))
+        .map(async (entry) => {
+          const filePath = path.join(configDir, entry)
+          try {
+            const stats = await fs.stat(filePath)
+            if (stats.mtimeMs > cutoff) return
+            await fs.unlink(filePath)
+            debugLog(`Removed stale config file: ${entry}`)
+          } catch (error) {
+            // Another instance may be sweeping the same directory
+            debugLog(`Could not remove stale config file ${entry}`, error)
+          }
+        }),
+    )
+  } catch (error) {
+    debugLog('Could not sweep stale config files', error)
+  }
+}
+
 export async function writeTextFile(serverUrlHash: string, filename: string, text: string): Promise<void> {
   try {
     await ensureConfigDir()

--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -4,6 +4,7 @@ import * as mcpAuthConfig from './mcp-auth-config'
 import type { OAuthProviderOptions } from './types'
 import type { AuthorizationServerMetadata } from './authorization-server-metadata'
 import { refreshAuthorization } from '@modelcontextprotocol/sdk/client/auth.js'
+import { openBrowser } from './open-browser'
 
 vi.mock('./mcp-auth-config')
 vi.mock('./authorization-server-metadata', () => ({
@@ -24,6 +25,9 @@ vi.mock('@modelcontextprotocol/sdk/client/auth.js', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
   refreshAuthorization: vi.fn(),
 }))
+vi.mock('./open-browser', () => ({ openBrowser: vi.fn().mockResolvedValue(true) }))
+
+const openBrowserMock = vi.mocked(openBrowser)
 
 describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
   let provider: NodeOAuthClientProvider
@@ -182,40 +186,136 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       mockWriteTextFile = vi.mocked(mcpAuthConfig.writeTextFile)
       mockWriteTextFile.mockResolvedValue(undefined)
       mockReadTextFile.mockResolvedValue('test-verifier')
+      // No competing instance unless a scenario says so
+      vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(true)
     })
 
-    it('should save the code verifier to a filename scoped to the current process ID', async () => {
+    it('should save the code verifier to a filename scoped to the authorization state', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       await provider.saveCodeVerifier('test-verifier')
 
-      expect(mockWriteTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`, 'test-verifier')
+      expect(mockWriteTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`, 'test-verifier')
       // Two processes for the same server must never target the same filename
       expect(mockWriteTextFile).not.toHaveBeenCalledWith('test-hash', 'code_verifier.txt', 'test-verifier')
     })
 
-    it('should read the code verifier back from the same process-scoped filename', async () => {
+    it('should not open a second tab while another instance has one pending', async () => {
+      vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(false)
+      vi.mocked(mcpAuthConfig.readJsonFile).mockResolvedValue({ state: 'other-instance-state', timestamp: Date.now() } as any)
+      provider = new NodeOAuthClientProvider(defaultOptions)
+      await provider.redirectToAuthorization(new URL('https://auth.example.com/authorize'))
+
+      await provider.openPendingAuthorization()
+
+      expect(openBrowserMock).not.toHaveBeenCalled()
+    })
+
+    it('should open a tab when the pending one is too old to still be useful', async () => {
+      vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(false)
+      const fourMinutesAgo = Date.now() - 4 * 60 * 1000
+      vi.mocked(mcpAuthConfig.readJsonFile).mockResolvedValue({ state: 'other-instance-state', timestamp: fourMinutesAgo } as any)
+      provider = new NodeOAuthClientProvider(defaultOptions)
+      await provider.redirectToAuthorization(new URL('https://auth.example.com/authorize'))
+
+      await provider.openPendingAuthorization()
+
+      expect(openBrowserMock).toHaveBeenCalled()
+    })
+
+    it('should read the verifier of the flow the code came from, not its own', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+      // A tab opened by an instance the host has since killed
+      provider.useAuthorizationState('state-from-another-instance')
+
+      await provider.codeVerifier()
+
+      expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', 'code_verifier_state-from-another-instance.txt', expect.any(String))
+      expect(mockReadTextFile).not.toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`, expect.any(String))
+    })
+
+    it('should read the code verifier back from the same flow-scoped filename', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       await provider.codeVerifier()
 
-      expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`, expect.any(String))
+      expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`, expect.any(String))
     })
 
-    it('should delete the process-scoped verifier file when invalidating the verifier scope', async () => {
+    it('should open exactly one tab when two instances start together', async () => {
+      // Both instances find no marker; only the one whose exclusive create wins may open a tab
+      vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValueOnce(true).mockResolvedValueOnce(false)
+      vi.mocked(mcpAuthConfig.readJsonFile).mockResolvedValue({ state: 'winner-state', timestamp: Date.now() } as any)
+
+      for (const _ of [0, 1]) {
+        const instance = new NodeOAuthClientProvider(defaultOptions)
+        await instance.redirectToAuthorization(new URL('https://auth.example.com/authorize'))
+        await instance.openPendingAuthorization()
+      }
+
+      expect(openBrowserMock).toHaveBeenCalledTimes(1)
+    })
+
+    it('should redeem a code with the client the flow was started with', async () => {
+      // The instance that opened the tab listens on 38923; a sibling that could not have that port
+      // re-registered and overwrote the shared client_info.json before the code came back
+      const openTabFlow = {
+        clientInformation: { client_id: 'client-of-the-open-tab', redirect_uris: ['http://localhost:38923/oauth/callback'] },
+        redirectUri: 'http://localhost:38923/oauth/callback',
+      }
+      vi.mocked(mcpAuthConfig.readJsonFile).mockImplementation(async (_hash: any, filename: string) =>
+        filename.startsWith('flow_client_') ? openTabFlow : ({ client_id: 'client-a-sibling-registered' } as any),
+      )
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      await provider.useAuthorizationState('11111111-2222-3333-4444-555555555555')
+
+      // Both halves of the exchange must describe the flow the code belongs to
+      await expect(provider.clientInformation()).resolves.toMatchObject({ client_id: 'client-of-the-open-tab' })
+      expect(provider.redirectUrl).toBe('http://localhost:38923/oauth/callback')
+    })
+
+    it('should fall back to its own client and callback when the code is from its own flow', async () => {
+      vi.mocked(mcpAuthConfig.readJsonFile).mockResolvedValue({ client_id: 'client-from-shared-file' } as any)
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      await expect(provider.clientInformation()).resolves.toMatchObject({ client_id: 'client-from-shared-file' })
+      expect(provider.redirectUrl).toBe('http://localhost:8080/oauth/callback')
+    })
+
+    it('should ignore an authorization state it could not have issued', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      // A crafted state would otherwise be interpolated straight into a config file path
+      provider.useAuthorizationState('../../../../etc/passwd')
+      await provider.codeVerifier()
+
+      expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`, expect.any(String))
+      expect(mockReadTextFile).not.toHaveBeenCalledWith('test-hash', expect.stringContaining('..'), expect.any(String))
+    })
+
+    it('should sweep verifiers abandoned by instances that lost the flow', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      await provider.saveTokens({ access_token: 'token', token_type: 'Bearer' } as any)
+
+      expect(vi.mocked(mcpAuthConfig.deleteStaleConfigFiles)).toHaveBeenCalledWith('test-hash', 'code_verifier_', expect.any(Number))
+    })
+
+    it('should delete the flow-scoped verifier file when invalidating the verifier scope', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       await provider.invalidateCredentials('verifier')
 
-      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`)
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`)
     })
 
-    it('should delete the process-scoped verifier file when invalidating all credentials', async () => {
+    it('should delete the flow-scoped verifier file when invalidating all credentials', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       await provider.invalidateCredentials('all')
 
-      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`)
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`)
     })
   })
 

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -1,4 +1,3 @@
-import open from 'open'
 import { z } from 'zod'
 import { OAuthClientProvider, refreshAuthorization, selectResourceURL } from '@modelcontextprotocol/sdk/client/auth.js'
 import {
@@ -8,7 +7,16 @@ import {
   OAuthTokensSchema,
 } from '@modelcontextprotocol/sdk/shared/auth.js'
 import type { OAuthProviderOptions, StaticOAuthClientMetadata } from './types'
-import { readJsonFile, writeJsonFile, readTextFile, writeTextFile, deleteConfigFile } from './mcp-auth-config'
+import {
+  readJsonFile,
+  writeJsonFile,
+  readTextFile,
+  writeTextFile,
+  deleteConfigFile,
+  claimConfigFile,
+  deleteStaleConfigFiles,
+} from './mcp-auth-config'
+import { openBrowser } from './open-browser'
 import { StaticOAuthClientInformationFull } from './types'
 import { log, debugLog, buildRedirectUrl, MCP_REMOTE_VERSION } from './utils'
 import { sanitizeUrl } from 'strict-url-sanitise'
@@ -28,6 +36,53 @@ const OAuthTokensWithExpiresAtSchema = OAuthTokensSchema.extend({
   expires_at: z.coerce.number().optional(),
 })
 type OAuthTokensWithExpiresAt = z.infer<typeof OAuthTokensWithExpiresAtSchema>
+
+const PENDING_AUTH_FILE = 'pending_auth.json'
+const CODE_VERIFIER_PREFIX = 'code_verifier_'
+const FLOW_CLIENT_PREFIX = 'flow_client_'
+
+/**
+ * The client registration and callback URL an authorization flow was started with.
+ *
+ * Instances share one client_info.json but listen on different ports, so a sibling starting
+ * mid-flow re-registers and overwrites it. The code has to be redeemed with what it was issued to.
+ */
+type FlowClient = {
+  clientInformation: OAuthClientInformationFull
+  redirectUri: string
+}
+
+const FlowClientSchema = {
+  async parseAsync(data: any) {
+    if (typeof data !== 'object' || data === null) return null
+    if (typeof data.redirectUri !== 'string' || typeof data.clientInformation?.client_id !== 'string') return null
+    return data as FlowClient
+  },
+}
+
+/**
+ * The shape of the authorization state we issue, and the only shape we will put in a filename.
+ *
+ * Any local process can reach the callback server, so a crafted state would otherwise traverse
+ * out of the config directory.
+ */
+const ISSUED_STATE = /^[A-Za-z0-9-]{1,64}$/
+
+/** How long an unfinished authorization tab is assumed to still be worth waiting for. */
+const PENDING_AUTH_TTL = 3 * 60 * 1000
+
+type PendingAuthorization = {
+  state: string
+  timestamp: number
+}
+
+const PendingAuthorizationSchema = {
+  async parseAsync(data: any) {
+    if (typeof data !== 'object' || data === null) return null
+    if (typeof data.state !== 'string' || typeof data.timestamp !== 'number') return null
+    return data as PendingAuthorization
+  },
+}
 
 /**
  * Implements the OAuthClientProvider interface for Node.js environments.
@@ -56,6 +111,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private wwwAuthenticateScope: string | undefined
   /** In-flight proactive refresh, so concurrent requests share one refresh_token use */
   private refreshInFlight: Promise<OAuthTokensWithExpiresAt | undefined> | null = null
+  private pendingAuthorizationUrl: string | undefined
+  private incomingState: string | undefined
+  /** Cached by clientInformation(), which the SDK always calls before it needs the redirect URI */
+  private incomingFlowClientSync: FlowClient | undefined
 
   /**
    * Creates a new NodeOAuthClientProvider
@@ -100,6 +159,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   }
 
   get redirectUrl(): string {
+    // The authorization server checks this against the URI it saw on /authorize
+    if (this.incomingFlowClientSync) {
+      return this.incomingFlowClientSync.redirectUri
+    }
     return buildRedirectUrl(this.options.host, this.options.callbackPort, this.callbackPath)
   }
 
@@ -209,6 +272,13 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    */
   async clientInformation(): Promise<OAuthClientInformationFull | undefined> {
     debugLog('Reading client info')
+    const flowClient = await this.incomingFlowClient()
+    if (flowClient) {
+      debugLog('Using the client registration of the flow that produced this code', {
+        client_id: flowClient.clientInformation.client_id,
+      })
+      return flowClient.clientInformation
+    }
     if (this.staticOAuthClientInfo) {
       debugLog('Returning static client info')
       this._clientInfo = this.staticOAuthClientInfo
@@ -393,6 +463,12 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
 
     await writeJsonFile(this.serverUrlHash, 'tokens.json', tokensToSave)
+    await deleteConfigFile(this.serverUrlHash, PENDING_AUTH_FILE)
+    await deleteConfigFile(this.serverUrlHash, this.codeVerifierFile(this.incomingState ?? this._state))
+    await deleteConfigFile(this.serverUrlHash, this.flowClientFile(this.incomingState ?? this._state))
+    // Records left behind by instances that lost the race to complete this flow
+    await deleteStaleConfigFiles(this.serverUrlHash, CODE_VERIFIER_PREFIX, PENDING_AUTH_TTL)
+    await deleteStaleConfigFiles(this.serverUrlHash, FLOW_CLIENT_PREFIX, PENDING_AUTH_TTL)
   }
 
   /**
@@ -415,33 +491,93 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 
-    debugLog('Redirecting to authorization URL', authorizationUrl.toString())
+    if (this._clientInfo) {
+      await writeJsonFile(this.serverUrlHash, this.flowClientFile(this._state), {
+        clientInformation: this._clientInfo,
+        redirectUri: this.redirectUrl,
+      })
+    }
 
-    try {
-      await open(sanitizeUrl(authorizationUrl.toString()))
+    debugLog('Deferring browser launch until this instance is known to own the callback server')
+    this.pendingAuthorizationUrl = sanitizeUrl(authorizationUrl.toString())
+  }
+
+  /**
+   * Opens the deferred authorization URL, once this instance is known to own the callback server
+   */
+  async openPendingAuthorization(): Promise<void> {
+    const url = this.pendingAuthorizationUrl
+    if (!url) {
+      debugLog('No pending authorization URL to open')
+      return
+    }
+    this.pendingAuthorizationUrl = undefined
+
+    // Claimed rather than read-then-written: instances starting together would both see no marker
+    if (!(await claimConfigFile(this.serverUrlHash, PENDING_AUTH_FILE, { state: this._state, timestamp: Date.now() }))) {
+      const pending = await readJsonFile<PendingAuthorization>(this.serverUrlHash, PENDING_AUTH_FILE, PendingAuthorizationSchema)
+      if (pending && pending.state !== this._state && Date.now() - pending.timestamp < PENDING_AUTH_TTL) {
+        log('An authorization tab is already open for this server; waiting for it to be completed.')
+        debugLog('Reusing the authorization flow of an earlier instance', pending)
+        return
+      }
+      // The marker is ours, or belongs to a flow too old to still be waited on
+      await writeJsonFile(this.serverUrlHash, PENDING_AUTH_FILE, { state: this._state, timestamp: Date.now() })
+    }
+
+    if (await openBrowser(url)) {
       log('Browser opened automatically.')
-    } catch (error) {
-      log('Could not open browser automatically. Please copy and paste the URL above into your browser.')
-      debugLog('Failed to open browser', error)
+    } else {
+      log('Could not open a browser automatically. Please copy and paste the URL above into your browser.')
     }
   }
 
   /**
    * Saves the PKCE code verifier
    *
-   * The filename is scoped to the current process ID. Multiple mcp-remote
-   * processes can be started concurrently for the same server (e.g. an MCP
-   * host reconnecting or launching duplicate instances) - since coordination
-   * between those processes is currently disabled on Windows (see
-   * coordination.ts), each process must keep its own verifier so a second
-   * process can't overwrite the first one's file mid-flow and break the
-   * PKCE exchange for whichever process the browser callback actually
-   * reaches. See https://github.com/geelen/mcp-remote/issues/235.
+   * The filename is scoped to this flow's authorization state, so concurrent instances neither
+   * overwrite each other's verifier nor redeem a code with the wrong one
+   * (https://github.com/geelen/mcp-remote/issues/235).
    * @param codeVerifier The code verifier to save
    */
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
-    debugLog('Saving code verifier')
-    await writeTextFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`, codeVerifier)
+    debugLog('Saving code verifier', { state: this._state })
+    await writeTextFile(this.serverUrlHash, this.codeVerifierFile(this._state), codeVerifier)
+  }
+
+  /**
+   * Records the state an authorization code came back with, so the verifier saved for that flow
+   * is the one used to redeem it, whichever instance started the flow
+   */
+  async useAuthorizationState(state: string): Promise<void> {
+    if (!ISSUED_STATE.test(state)) {
+      log('Ignoring an authorization state this client could not have issued')
+      debugLog('Rejected authorization state', { state })
+      return
+    }
+    debugLog('Using code verifier from the flow that produced this code', { state })
+    this.incomingState = state
+    // Loaded now rather than on demand: the SDK reads `redirectUrl` before it asks for the client
+    // information, so the record has to be in hand before either is touched.
+    await this.incomingFlowClient()
+  }
+
+  private codeVerifierFile(state: string): string {
+    return `${CODE_VERIFIER_PREFIX}${state}.txt`
+  }
+
+  private flowClientFile(state: string): string {
+    return `${FLOW_CLIENT_PREFIX}${state}.json`
+  }
+
+  /**
+   * The record for the flow whose code we are redeeming, if that flow is not this instance's own
+   */
+  private async incomingFlowClient(): Promise<FlowClient | undefined> {
+    if (!this.incomingState) return undefined
+    const flowClient = await readJsonFile<FlowClient>(this.serverUrlHash, this.flowClientFile(this.incomingState), FlowClientSchema)
+    this.incomingFlowClientSync = flowClient ?? undefined
+    return this.incomingFlowClientSync
   }
 
   /**
@@ -449,8 +585,9 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    * @returns The code verifier
    */
   async codeVerifier(): Promise<string> {
-    debugLog('Reading code verifier')
-    const verifier = await readTextFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`, 'No code verifier saved for session')
+    const state = this.incomingState ?? this._state
+    debugLog('Reading code verifier', { state })
+    const verifier = await readTextFile(this.serverUrlHash, this.codeVerifierFile(state), 'No code verifier saved for session')
     debugLog('Code verifier found:', !!verifier)
     return verifier
   }
@@ -467,7 +604,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
         await Promise.all([
           deleteConfigFile(this.serverUrlHash, 'client_info.json'),
           deleteConfigFile(this.serverUrlHash, 'tokens.json'),
-          deleteConfigFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`),
+          deleteConfigFile(this.serverUrlHash, this.codeVerifierFile(this.incomingState ?? this._state)),
         ])
         this._clientInfo = undefined
         debugLog('All credentials invalidated')
@@ -485,7 +622,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
         break
 
       case 'verifier':
-        await deleteConfigFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`)
+        await deleteConfigFile(this.serverUrlHash, this.codeVerifierFile(this.incomingState ?? this._state))
         debugLog('Code verifier invalidated')
         break
 

--- a/src/lib/open-browser.ts
+++ b/src/lib/open-browser.ts
@@ -1,0 +1,77 @@
+import { spawn } from 'child_process'
+import open from 'open'
+import { log, debugLog } from './utils'
+
+/**
+ * Waits for a spawned helper and reports whether it actually succeeded, since helpers such as
+ * xdg-open exit well after the spawn resolves
+ */
+function waitForHelper(child: ReturnType<typeof spawn>, name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    let stderr = ''
+    child.stderr?.on('data', (chunk) => {
+      stderr += String(chunk)
+    })
+    child.once('error', (error) => {
+      debugLog(`Browser helper ${name} failed to start`, error)
+      resolve(false)
+    })
+    child.once('exit', (code) => {
+      if (code === 0) {
+        debugLog(`Browser helper ${name} exited cleanly`)
+        resolve(true)
+        return
+      }
+      debugLog(`Browser helper ${name} exited with a failure`, { code, stderr: stderr.slice(0, 500) })
+      resolve(false)
+    })
+  })
+}
+
+/** Helpers to try on Linux, in order, when the bundled opener does not work. */
+const LINUX_FALLBACKS: Array<{ command: string; args: (url: string) => string[] }> = [
+  { command: '/usr/bin/xdg-open', args: (url) => [url] },
+  { command: 'gio', args: (url) => ['open', url] },
+  { command: 'x-www-browser', args: (url) => [url] },
+  { command: 'sensible-browser', args: (url) => [url] },
+]
+
+/**
+ * Opens a URL in the user's browser, falling back through the platform's other openers.
+ *
+ * @returns True if one of the helpers reported success
+ */
+export async function openBrowser(url: string): Promise<boolean> {
+  debugLog('Browser launch environment', {
+    DISPLAY: process.env.DISPLAY,
+    WAYLAND_DISPLAY: process.env.WAYLAND_DISPLAY,
+    DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS ? 'set' : undefined,
+    BROWSER: process.env.BROWSER,
+    PATH: process.env.PATH,
+  })
+
+  try {
+    if (await waitForHelper(await open(url), 'open')) {
+      return true
+    }
+  } catch (error) {
+    debugLog('Failed to spawn the bundled opener', error)
+  }
+
+  if (process.platform !== 'linux') {
+    return false
+  }
+
+  for (const fallback of LINUX_FALLBACKS) {
+    try {
+      log(`Trying ${fallback.command} to open the browser...`)
+      if (await waitForHelper(spawn(fallback.command, fallback.args(url), { stdio: 'ignore' }), fallback.command)) {
+        return true
+      }
+    } catch (error) {
+      debugLog(`Failed to spawn ${fallback.command}`, error)
+    }
+  }
+
+  return false
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -62,3 +62,9 @@ export interface OAuthCallbackServerOptions {
 // optional tatic OAuth client information
 export type StaticOAuthClientMetadata = OAuthClientMetadata | null | undefined
 export type StaticOAuthClientInformationFull = OAuthClientInformationFull | null | undefined
+
+/** The authorization code delivered to the callback server, with the state that identifies its flow. */
+export type AuthCodeResult = {
+  code: string
+  state?: string
+}

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1633,7 +1633,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
 
     const response = await fetch(`http://127.0.0.1:${result.actualPort}/custom/callback?code=test-code`)
     expect(response.status).toBe(200)
-    await expect(result.waitForAuthCode()).resolves.toBe('test-code')
+    await expect(result.waitForAuthCode()).resolves.toEqual({ code: 'test-code', state: undefined })
 
     // The default path must not be served when it was overridden, otherwise the redirect URI
     // we advertise and the endpoint we listen on can silently disagree

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@ import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontex
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { OAuthClientInformationFull, OAuthClientInformationFullSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
-import { OAuthCallbackServerOptions, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './types'
+import { AuthCodeResult, OAuthCallbackServerOptions, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './types'
 import { getConfigDir, getConfigFilePath, readJsonFile } from './mcp-auth-config'
 import {
   discoverProtectedResourceMetadata,
@@ -522,7 +522,7 @@ export async function discoverOAuthServerInfo(
  * Type for the auth initialization function
  */
 export type AuthInitializer = () => Promise<{
-  waitForAuthCode: () => Promise<string>
+  waitForAuthCode: () => Promise<AuthCodeResult>
   skipBrowserAuth: boolean
 }>
 
@@ -701,15 +701,26 @@ export async function connectToRemoteServer(
 
       log('Authentication required. Waiting for authorization...')
 
+      // Deferred until here: this instance owns the callback server, so the tab should carry its
+      // client_id and PKCE verifier
+      if ('openPendingAuthorization' in authProvider && typeof authProvider.openPendingAuthorization === 'function') {
+        await authProvider.openPendingAuthorization()
+      }
+
       // Wait for the authorization code from the callback
       debugLog('Waiting for auth code from callback server')
-      const code = await waitForAuthCode()
+      const { code, state } = await waitForAuthCode()
       debugLog('Received auth code from callback server')
 
       // Checked before the exchange, not after: an authorization code is single-use (RFC 6749
       // 4.1.2) and the callback server hands back the same retained code on a second call, so
       // exchanging it again fails with invalid_grant and masks this message.
       giveUpIfAlreadyRetried()
+
+      // The code may come from a flow another instance started; redeem it with that flow's details
+      if (state && 'useAuthorizationState' in authProvider && typeof authProvider.useAuthorizationState === 'function') {
+        await authProvider.useAuthorizationState(state)
+      }
 
       try {
         log('Completing authorization...')
@@ -755,15 +766,16 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   server: Server
   actualPort: number
   authCode: string | null
-  waitForAuthCode: () => Promise<string>
-  authCompletedPromise: Promise<string>
+  waitForAuthCode: () => Promise<AuthCodeResult>
+  authCompletedPromise: Promise<AuthCodeResult>
 }> {
   let authCode: string | null = null
+  let authState: string | null = null
   const app = express()
 
   // Create a promise to track when auth is completed
-  let authCompletedResolve: (code: string) => void
-  const authCompletedPromise = new Promise<string>((resolve) => {
+  let authCompletedResolve: (result: AuthCodeResult) => void
+  const authCompletedPromise = new Promise<AuthCodeResult>((resolve) => {
     authCompletedResolve = resolve
   })
 
@@ -810,14 +822,16 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   // OAuth callback endpoint
   app.get(options.path, (req, res) => {
     const code = req.query.code as string | undefined
+    const state = req.query.state as string | undefined
     if (!code) {
       res.status(400).send('Error: No authorization code received')
       return
     }
 
     authCode = code
+    authState = state ?? null
     log('Auth code received, resolving promise')
-    authCompletedResolve(code)
+    authCompletedResolve({ code, state })
 
     res.send(`
       Authorization successful!
@@ -831,7 +845,7 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
     `)
 
     // Notify main flow that auth code is available
-    options.events.emit('auth-code-received', code)
+    options.events.emit('auth-code-received', code, state)
   })
 
   // Bind the server, falling back to a random port on EADDRINUSE (unless strictPort is set)
@@ -872,15 +886,15 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
     })
   })
 
-  const waitForAuthCode = (): Promise<string> => {
+  const waitForAuthCode = (): Promise<AuthCodeResult> => {
     return new Promise((resolve) => {
       if (authCode) {
-        resolve(authCode)
+        resolve({ code: authCode, state: authState ?? undefined })
         return
       }
 
-      options.events.once('auth-code-received', (code) => {
-        resolve(code)
+      options.events.once('auth-code-received', (code: string, state?: string) => {
+        resolve({ code, state })
       })
     })
   }


### PR DESCRIPTION
## The problem

Claude Desktop starts several instances of `mcp-remote` for one server and stops them a few seconds later, then starts more. The coordination between instances assumes the instance that begins an authorization stays alive to finish it, so on that host authentication either hangs until the client times out, or completes in the browser and is then rejected.

Reproducing it needs nothing unusual: install any remote MCP server that requires OAuth as a Claude Desktop extension with no cached tokens, and watch `~/.mcp-auth/<hash>_debug.log`. This looks like the same underlying behaviour reported in #245, #251, #298, #141 and #317.

A run before this change, trimmed to the interesting lines:

```
[A] Browser opened automatically.            <- tab 1
[A] Removed lockfile on exit                 <- the host stopped it, ~3s in
[B] Another instance is handling authentication on port 38923 (pid: A)
[B] Fetch error during poll {}               <- repeated until the host gave up
[C] Browser opened automatically.            <- tab 2, different client_id
[C] Authorization error during finishAuth {"errorMessage":"incorrect code_verifier"}
```

Rebased onto `v0.2.1`. #323 fixed the secondary instance hanging once a sibling had signed in; this PR keeps that fix and repairs the flow it was waiting on.

## What breaks today

### The code is redeemed with the wrong PKCE verifier

`incorrect code_verifier`, and the sign-in never completes.

Since #315 the verifier is saved per process, as `code_verifier_<pid>.txt`. The host runs two to five instances per server and stops them at will, so the instance holding the callback server when the user completes the tab is usually not the one that generated the challenge.

The verifier is now keyed by the authorization `state`, which the callback carries, so whichever instance holds the callback server can redeem a flow another instance started. This keeps the per-flow isolation #315 introduced without tying it to a process staying alive.

### The code is redeemed with the wrong client registration

`authorization code does not exist`, after a browser flow the user completed normally.

Instances share one `client_info.json` but each listens on its own port. The first instance takes the deterministic port; the others cannot, land on random ones, find a cached registration whose redirect URI is not theirs, discard it (#292) and register again - overwriting the shared file. The instance that then redeems the code presents a client the code was never issued to.

The client registration and callback URL are now recorded per flow, next to that flow's verifier, and used when a code arrives carrying its state.

### Every instance opens its own tab

Two to five tabs, each with its own `client_id` and challenge. The competing authorizations also clobber each other's CSRF state at the authorization server, so the tab the user is looking at can fail with a CSRF mismatch.

The browser was opened from `redirectToAuthorization`, before coordination had decided who owns the callback server. It is now opened after coordination, by the instance that owns it, and an unfinished tab from an earlier instance is waited on instead of opening a competing one.

### Waiting on an instance that is gone never ends

The server never comes up and the host times it out.

`waitForAuthentication` retried every two seconds forever when the sibling stopped answering, so the `Taking over authentication process...` branch right below it could not be reached. It now returns `false` once the lock owner is gone, or after the endpoint has been unreachable for six seconds.

### Any instance could delete another's lockfile

The `exit` handler unlinked `lock.json` unconditionally, so a short-lived duplicate stripped the lock from the instance that was driving the flow. It is now removed only by the process recorded in it.

### A failed browser helper was reported as success

`open()` resolves when the helper is spawned. On a host that runs the server without the graphical session variables, `xdg-open` exits 3 immediately afterwards and no window appears, while the log says `Browser opened automatically.` and the user is given no hint that the URL has to be copied by hand.

Helpers are now checked for their exit status, with a fallback chain on Linux (`/usr/bin/xdg-open`, `gio open`, `x-www-browser`, `sensible-browser`). Claude Desktop extensions are exactly such a host: both the bundled opener and `xdg-open` fail there, and only `gio`, which goes through the portal, opens anything.

## This PR also does

- **Rejects an authorization state this client could not have issued.** The state arrives on the callback query, which any local process can reach, and is interpolated into a filename; a crafted one escaped the config directory on read and on delete.
- **Sweeps flow-scoped files once a flow succeeds.** Naming them after a one-off flow means nothing ever names them again, so every abandoned flow left one behind for good. The sweep is age-checked so a concurrent instance's live flow is untouched.
- **Claims the pending-tab marker with an exclusive create** instead of read-then-write, so instances starting together do not both conclude that no tab is open.

## Testing

`pnpm check` and `pnpm test:unit` pass. The suite goes from 173 to 189 tests: a new `src/lib/coordination.test.ts` covers lockfile ownership and the waiting behaviour, `mcp-auth-config.test.ts` covers the exclusive claim and the sweep, and the provider tests cover the state-keyed verifier, the flow-scoped client registration and tab reuse. The existing tests that encoded the old contracts were updated. Each regression test was confirmed to fail against the unfixed code.

Verified end to end against an OAuth-protected MCP server on Claude Desktop: one tab, authentication completes after the host restarts the instance mid-flow, and the remaining instances pick up the tokens.
