### PR TITLE
fix: implement OAuth re-authentication flow on server UnauthorizedError when local to remote messages are sent

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -81,6 +81,7 @@ async function runClient(
     authorizationServerMetadata: discoveryResult.authorizationServerMetadata,
     protectedResourceMetadata: discoveryResult.protectedResourceMetadata,
     wwwAuthenticateScope: discoveryResult.wwwAuthenticateScope,
+    events,
   })
 
   // Create the client

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -54,6 +54,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private authorizationServerMetadata: AuthorizationServerMetadata | undefined
   private protectedResourceMetadata: ProtectedResourceMetadata | undefined
   private wwwAuthenticateScope: string | undefined
+  private events?: import('events').EventEmitter
   /** In-flight proactive refresh, so concurrent requests share one refresh_token use */
   private refreshInFlight: Promise<OAuthTokensWithExpiresAt | undefined> | null = null
 
@@ -78,6 +79,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     this.authorizationServerMetadata = options.authorizationServerMetadata
     this.protectedResourceMetadata = options.protectedResourceMetadata
     this.wwwAuthenticateScope = options.wwwAuthenticateScope
+    this.events = options.events
 
     // The SDK feeds one `resource` value into the authorization, token and refresh requests
     // (selectResourceURL -> startAuthorization / fetchToken / refreshAuthorization). Deciding
@@ -400,6 +402,12 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    * @param authorizationUrl The URL to redirect to
    */
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    // Reset the auth code to null when starting a new authorization flow
+    if (this.events) {
+      debugLog('Emitting reset-auth-code event')
+      this.events.emit('reset-auth-code')
+    }
+
     // Optionally fetch metadata for debugging/informational purposes (non-blocking)
     this.getAuthorizationServerMetadata().catch(() => {
       // Ignore errors, metadata is optional

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -41,6 +41,8 @@ export interface OAuthProviderOptions {
   protectedResourceMetadata?: ProtectedResourceMetadata
   /** Scope extracted from WWW-Authenticate header */
   wwwAuthenticateScope?: string
+  /** Event emitter for OAuth flow coordination */
+  events?: EventEmitter
 }
 
 /**

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -133,13 +133,16 @@ export function mcpProxy({
   transportToClient,
   transportToServer,
   ignoredTools = [],
+  authInitializer,
 }: {
   transportToClient: Transport
-  transportToServer: Transport
+  transportToServer: Transport | SSEClientTransport | StreamableHTTPClientTransport
   ignoredTools?: string[]
+  authInitializer?: AuthInitializer
 }) {
   let transportToClientClosed = false
   let transportToServerClosed = false
+  let reAuthPromise: Promise<void> | null = null
   let initializeRequestId: string | number | undefined
   let lastInitialize: Message | null = null
   let reinitSeq = 0
@@ -360,6 +363,61 @@ export function mcpProxy({
       await transportToServer.send(message)
       return
     } catch (error) {
+      if (error instanceof UnauthorizedError && authInitializer) {
+        // If a re-auth flow is already in progress, wait for it instead of starting another
+        if (reAuthPromise) {
+          debugLog('onSendError: Re-auth already in progress, waiting for it to complete')
+          await reAuthPromise
+          if (message) {
+            log('onSendError: Retrying failed message after shared re-authentication')
+            await transportToServer.send(message)
+            log('onSendError: Message successfully sent after shared re-authentication')
+          }
+          return
+        }
+
+        reAuthPromise = (async () => {
+          debugLog('onSendError: Calling authInitializer to start auth flow')
+          const { waitForAuthCode, skipBrowserAuth } = await authInitializer()
+
+          if (skipBrowserAuth) {
+            log('onSendError: Authentication required but skipping browser auth - using shared auth')
+          } else {
+            log('onSendError: Authentication required. Waiting for authorization...')
+          }
+
+          // Wait for the authorization code from the callback
+          debugLog('onSendError: Waiting for auth code from callback server')
+          const code = await waitForAuthCode()
+          debugLog('onSendError: Received auth code from callback server')
+
+          log('onSendError: Completing authorization...')
+          // Check if transport has finishAuth method (SSEClientTransport or StreamableHTTPClientTransport)
+          if ('finishAuth' in transportToServer && typeof transportToServer.finishAuth === 'function') {
+            await transportToServer.finishAuth(code)
+            log('onSendError: Authorization completed successfully')
+          } else {
+            log('onSendError: Warning: Transport does not support finishAuth method')
+          }
+        })()
+
+        try {
+          await reAuthPromise
+
+          // Retry sending the failed message after successful re-authentication
+          if (message) {
+            log('onSendError: Retrying failed message after re-authentication')
+            await transportToServer.send(message)
+            log('onSendError: Message successfully sent after re-authentication')
+          }
+        } catch (error) {
+          log('onSendError: Error completing authorization:', error)
+        } finally {
+          reAuthPromise = null
+        }
+        return
+      }
+
       // Re-initializing in response to a failed initialize would loop
       if (!isSessionExpired(error as Error) || message.method === 'initialize') {
         onServerError(error as Error)
@@ -749,6 +807,13 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
     authCompletedResolve = resolve
   })
 
+  // Listen for reset-auth-code event to reset authCode to null
+  options.events.on('reset-auth-code', () => {
+    log('Resetting authCode to null due to new authorization flow')
+    debugLog('Received reset-auth-code event, resetting authCode')
+    authCode = null
+  })
+
   // Long-polling endpoint
   app.get('/wait-for-auth', (req, res) => {
     if (authCode) {
@@ -858,11 +923,13 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
     return new Promise((resolve) => {
       if (authCode) {
         resolve(authCode)
+        authCode = null
         return
       }
 
       options.events.once('auth-code-received', (code) => {
         resolve(code)
+        authCode = null
       })
     })
   }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -81,6 +81,7 @@ async function runProxy(
     authorizationServerMetadata: discoveryResult.authorizationServerMetadata,
     protectedResourceMetadata: discoveryResult.protectedResourceMetadata,
     wwwAuthenticateScope: discoveryResult.wwwAuthenticateScope,
+    events,
   })
 
   // Create the STDIO transport for local connections
@@ -129,6 +130,7 @@ async function runProxy(
       transportToClient: localTransport,
       transportToServer: remoteTransport,
       ignoredTools,
+      authInitializer,
     })
 
     // Start the local STDIO server


### PR DESCRIPTION
This pull request enhances the implementation of the OAuth 2.0 Authorization Code Flow in mcp-remote to ensure that the full authorization flow (namely redirection to authentication, user authentication, and authorization code to access token exchange) is executed every time an UnauthorizedError is thrown, not only when the mcp-remote process initially connects to the MCP server.

This behavior is required, for example, when a refresh token expires. Currently, when this occurs, the user is redirected to the authentication page and successfully obtains an authorization code; however, mcp-remote fails to complete the flow because it does not perform the authorization code to access token exchange.

To ensure that only one OAuth flow runs at a time regardless of how many messages fail with UnauthorizedError simultaneously, the reAuthPromise variable (scoped inside mcpProxy) has been introduced as a coalescing guard in onSendError:
* First caller (no reAuthPromise set) — creates the auth flow Promise (authInitializer() → waitForAuthCode() → finishAuth()), assigns it to reAuthPromise, awaits it, retries its own failed message, then clears reAuthPromise in finally.
* Concurrent callers (reAuthPromise already set) — skip the auth flow entirely, await reAuthPromise, then retry their own failed message.

Once the shared auth completes, all waiting callers retry their messages. The finally block resets reAuthPromise = null so a future UnauthorizedError (e.g. token expiry later) can trigger a fresh flow.

This pull request replaces #225, which can be discarded.