### PR TITLE
fix: stop a secondary instance hanging after another instance completes the sign-in

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -114,14 +114,6 @@ async function runClient(
       }
     }
 
-    // If auth was completed by another instance, just log that we'll use the auth from disk
-    if (authState.skipBrowserAuth) {
-      log('Authentication was completed by another instance - will use tokens from disk...')
-      // TODO: remove, the callback is happening before the tokens are exchanged
-      //  so we're slightly too early
-      await new Promise((res) => setTimeout(res, 1_000))
-    }
-
     return {
       waitForAuthCode: authState.waitForAuthCode,
       skipBrowserAuth: authState.skipBrowserAuth,

--- a/src/lib/connect-to-remote-server.test.ts
+++ b/src/lib/connect-to-remote-server.test.ts
@@ -7,6 +7,8 @@ const mockState = vi.hoisted(() => ({
   httpTransports: [] as Array<{ start: ReturnType<typeof vi.fn>; finishAuth: ReturnType<typeof vi.fn>; close: ReturnType<typeof vi.fn> }>,
   // Number of remaining `Client.connect` calls that should fail with an auth error.
   connectFailuresRemaining: 1,
+  // Every authorization code handed to `finishAuth`, in order.
+  finishAuthCalls: [] as string[],
 }))
 
 vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => {
@@ -19,7 +21,9 @@ vi.mock('@modelcontextprotocol/sdk/client/streamableHttp.js', () => {
   }
   class StreamableHTTPClientTransport {
     start = vi.fn().mockResolvedValue(undefined)
-    finishAuth = vi.fn().mockResolvedValue(undefined)
+    finishAuth = vi.fn(async (code: string) => {
+      mockState.finishAuthCalls.push(code)
+    })
     close = vi.fn().mockResolvedValue(undefined)
     constructor(
       public url: URL,
@@ -69,6 +73,7 @@ import { connectToRemoteServer } from './utils'
 describe('connectToRemoteServer', () => {
   beforeEach(() => {
     mockState.httpTransports.length = 0
+    mockState.finishAuthCalls.length = 0
     mockState.connectFailuresRemaining = 1
     // Keep test output quiet; connectToRemoteServer logs to stderr.
     vi.spyOn(console, 'error').mockImplementation(() => {})
@@ -124,5 +129,57 @@ describe('connectToRemoteServer', () => {
     const [mainTransport] = mockState.httpTransports
     expect(mainTransport.finishAuth).toHaveBeenCalledTimes(1)
     expect(mainTransport.finishAuth).toHaveBeenCalledWith('auth-code-456')
+  })
+
+  // What `coordinateAuth` hands a secondary instance once a sibling has finished the browser flow:
+  // there is no code to wait for, so awaiting one blocks until the MCP host times the server out.
+  const secondaryInstanceAuth = () => ({
+    waitForAuthCode: vi.fn(() => new Promise<string>(() => {})),
+    skipBrowserAuth: true,
+  })
+
+  it('reconnects instead of awaiting a code when a sibling completed the sign-in (regression: #322)', async () => {
+    const authState = secondaryInstanceAuth()
+    const authInitializer = vi.fn().mockResolvedValue(authState)
+
+    const connecting = connectToRemoteServer(null, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')
+    const HUNG = Symbol('hung')
+    const outcome = await Promise.race([
+      connecting.then(() => 'connected'),
+      new Promise((resolve) => setTimeout(() => resolve(HUNG), 1000)),
+    ])
+
+    expect(outcome).toBe('connected')
+
+    // The sibling already redeemed the authorization code, so there is nothing to exchange here
+    expect(authState.waitForAuthCode).not.toHaveBeenCalled()
+    expect(mockState.finishAuthCalls).toEqual([])
+  })
+
+  it('gives up rather than looping when a sibling instance tokens still do not work (regression: #322)', async () => {
+    const authInitializer = vi.fn().mockResolvedValue(secondaryInstanceAuth())
+    // Server keeps rejecting even after reading the sibling's tokens
+    mockState.connectFailuresRemaining = Number.MAX_SAFE_INTEGER
+
+    await expect(connectToRemoteServer(null, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')).rejects.toThrow(
+      'Already attempted reconnection',
+    )
+  })
+
+  it('does not re-exchange a spent authorization code when the retry also fails (regression: #322)', async () => {
+    // A real callback server retains the code it received, so a second call yields the same one
+    const authInitializer = vi.fn().mockResolvedValue({
+      waitForAuthCode: async () => 'auth-code-789',
+      skipBrowserAuth: false,
+    })
+    mockState.connectFailuresRemaining = Number.MAX_SAFE_INTEGER
+
+    // Without the guard ordering, the second exchange of 'auth-code-789' fails with invalid_grant,
+    // masking the real reason the connection is being abandoned.
+    await expect(connectToRemoteServer(null, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')).rejects.toThrow(
+      'Already attempted reconnection',
+    )
+
+    expect(mockState.finishAuthCalls).toEqual(['auth-code-789'])
   })
 })

--- a/src/lib/coordination.test.ts
+++ b/src/lib/coordination.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { writeJsonFile } from './mcp-auth-config'
+import { waitForTokensFromPrimary } from './coordination'
+
+describe('Feature: Token handoff between concurrent instances', () => {
+  const hash = 'handoff-test'
+  let configDir: string
+
+  beforeEach(async () => {
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-remote-handoff-'))
+    process.env.MCP_REMOTE_CONFIG_DIR = configDir
+    // coordinateAuth logs to stderr; keep the test output readable
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    delete process.env.MCP_REMOTE_CONFIG_DIR
+    await fs.rm(configDir, { recursive: true, force: true })
+  })
+
+  it('Scenario: Resolves once the primary instance persists its tokens', async () => {
+    // Given tokens that are not on disk yet - the primary's callback fired, but the code has
+    // not been exchanged. This is the window a fixed sleep used to gamble on.
+    const waiting = waitForTokensFromPrimary(hash, 5000)
+
+    // When the primary finishes the exchange and writes them
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    await writeJsonFile(hash, 'tokens.json', { access_token: 'from-primary', token_type: 'Bearer' })
+
+    // Then the secondary stops waiting
+    await expect(waiting).resolves.toBe(true)
+  })
+
+  it('Scenario: Gives up when the primary never writes them', async () => {
+    // Given a primary that signalled completion but never persisted anything
+    // Then the secondary reports failure instead of blocking forever
+    await expect(waitForTokensFromPrimary(hash, 500)).resolves.toBe(false)
+  })
+})

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -1,10 +1,15 @@
-import { checkLockfile, createLockfile, deleteLockfile, getConfigFilePath, LockfileData } from './mcp-auth-config'
+import { checkLockfile, createLockfile, deleteLockfile, getConfigFilePath, readJsonFile, LockfileData } from './mcp-auth-config'
+import { OAuthTokensSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { EventEmitter } from 'events'
 import { Server } from 'http'
 import express from 'express'
 import { AddressInfo } from 'net'
 import { unlinkSync } from 'fs'
 import { log, debugLog, setupOAuthCallbackServerWithLongPoll } from './utils'
+
+/** How long a secondary instance waits for the primary to persist the tokens it just obtained. */
+const TOKEN_HANDOFF_TIMEOUT_MS = 30_000
+const TOKEN_HANDOFF_POLL_INTERVAL_MS = 200
 
 export type AuthCoordinator = {
   initializeAuth: () => Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean; actualPort: number }>
@@ -158,6 +163,36 @@ export function createLazyAuthCoordinator(
 }
 
 /**
+ * Waits for the primary instance to persist the tokens it obtained.
+ *
+ * `waitForAuthentication` resolves as soon as the primary's callback server has *received* the
+ * authorization code, which is strictly earlier than the code being exchanged and the result
+ * written to disk. Reconnecting in that window reads no tokens and 401s again, so poll for the
+ * file rather than guessing at a fixed delay.
+ *
+ * @param serverUrlHash The hash of the server URL
+ * @returns True if tokens showed up before the timeout
+ */
+export async function waitForTokensFromPrimary(serverUrlHash: string, timeoutMs = TOKEN_HANDOFF_TIMEOUT_MS): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+
+  while (true) {
+    const tokens = await readJsonFile(serverUrlHash, 'tokens.json', OAuthTokensSchema)
+    if (tokens) {
+      debugLog('Tokens from the primary instance are on disk')
+      return true
+    }
+
+    if (Date.now() >= deadline) {
+      log(`Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the other instance to write its tokens`)
+      return false
+    }
+
+    await new Promise((resolve) => setTimeout(resolve, TOKEN_HANDOFF_POLL_INTERVAL_MS))
+  }
+}
+
+/**
  * Coordinates authentication between multiple instances of the client/proxy
  * @param serverUrlHash The hash of the server URL
  * @param callbackPort The port to use for the callback server
@@ -192,7 +227,11 @@ export async function coordinateAuth(
       debugLog('Waiting for authentication from other instance')
       const authCompleted = await waitForAuthentication(lockData.port)
 
-      if (authCompleted) {
+      // `waitForAuthentication` only reports that the primary's callback fired, which is strictly
+      // earlier than its token exchange finishing, so wait for the tokens themselves. If they
+      // never land, the primary failed somewhere we cannot observe - run the flow ourselves
+      // rather than hand back credentials that do not exist.
+      if (authCompleted && (await waitForTokensFromPrimary(serverUrlHash))) {
         log('Authentication completed by another instance. Using tokens from disk')
 
         // Setup a dummy server - the client will use tokens directly from disk
@@ -200,11 +239,15 @@ export async function coordinateAuth(
         const dummyPort = (dummyServer.address() as AddressInfo).port
         debugLog('Started dummy server', { port: dummyPort })
 
-        // This shouldn't actually be called in normal operation, but provide it for API compatibility
+        // Never called: callers must branch on `skipBrowserAuth` and reconnect with the tokens
+        // from disk instead of awaiting a code this instance will never receive. Kept only so the
+        // returned shape matches the primary's, and it rejects rather than hangs so a caller that
+        // regresses to awaiting it fails loudly instead of blocking until the host times out.
         const dummyWaitForAuthCode = () => {
           log('WARNING: waitForAuthCode called in secondary instance - this is unexpected')
-          // Return a promise that never resolves - the client should use the tokens from disk instead
-          return new Promise<string>(() => {})
+          return Promise.reject(
+            new Error('waitForAuthCode is not available in a secondary instance; reconnect using the tokens on disk instead'),
+          )
         }
 
         return {
@@ -217,9 +260,9 @@ export async function coordinateAuth(
           waitForAuthCode: dummyWaitForAuthCode,
           skipBrowserAuth: true,
         }
-      } else {
-        log('Taking over authentication process...')
       }
+
+      log('Taking over authentication process...')
     } catch (error) {
       log(`Error waiting for authentication: ${error}`)
       debugLog('Error waiting for authentication', error)

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -673,16 +673,43 @@ export async function connectToRemoteServer(
       debugLog('Calling authInitializer to start auth flow')
       const { waitForAuthCode, skipBrowserAuth } = await authInitializer()
 
-      if (skipBrowserAuth) {
-        log('Authentication required but skipping browser auth - using shared auth')
-      } else {
-        log('Authentication required. Waiting for authorization...')
+      const giveUpIfAlreadyRetried = () => {
+        if (!recursionReasons.has(REASON_AUTH_NEEDED)) return
+        const errorMessage = `Already attempted reconnection for reason: ${REASON_AUTH_NEEDED}. Giving up.`
+        log(errorMessage)
+        debugLog('Already attempted auth reconnection, giving up', {
+          recursionReasons: Array.from(recursionReasons),
+        })
+        throw new Error(errorMessage)
       }
+
+      // A concurrent instance ran the browser flow for us and persisted the tokens. There is no
+      // authorization code of our own to exchange - our callback server never received one, and
+      // the sibling's code has already been redeemed - so `waitForAuthCode` here is a promise
+      // that never settles (see coordinateAuth). Reconnect instead, which makes the auth provider
+      // re-read the tokens the sibling wrote (see https://github.com/geelen/mcp-remote/issues/322).
+      if (skipBrowserAuth) {
+        log('Authentication was completed by another instance - reconnecting with the tokens it wrote')
+        giveUpIfAlreadyRetried()
+
+        recursionReasons.add(REASON_AUTH_NEEDED)
+        debugLog('Recursively reconnecting using a sibling instance tokens', {
+          recursionReasons: Array.from(recursionReasons),
+        })
+        return connectToRemoteServer(client, serverUrl, authProvider, headers, authInitializer, transportStrategy, recursionReasons)
+      }
+
+      log('Authentication required. Waiting for authorization...')
 
       // Wait for the authorization code from the callback
       debugLog('Waiting for auth code from callback server')
       const code = await waitForAuthCode()
       debugLog('Received auth code from callback server')
+
+      // Checked before the exchange, not after: an authorization code is single-use (RFC 6749
+      // 4.1.2) and the callback server hands back the same retained code on a second call, so
+      // exchanging it again fails with invalid_grant and masks this message.
+      giveUpIfAlreadyRetried()
 
       try {
         log('Completing authorization...')
@@ -691,15 +718,6 @@ export async function connectToRemoteServer(
         // discover the correct token_endpoint. Falls back to `transport` for the with-client path.
         await (authChallengeTransport ?? transport).finishAuth(code)
         debugLog('Authorization completed successfully')
-
-        if (recursionReasons.has(REASON_AUTH_NEEDED)) {
-          const errorMessage = `Already attempted reconnection for reason: ${REASON_AUTH_NEEDED}. Giving up.`
-          log(errorMessage)
-          debugLog('Already attempted auth reconnection, giving up', {
-            recursionReasons: Array.from(recursionReasons),
-          })
-          throw new Error(errorMessage)
-        }
 
         // Track this reason for recursion
         recursionReasons.add(REASON_AUTH_NEEDED)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -106,14 +106,6 @@ async function runProxy(
       }
     }
 
-    // If auth was completed by another instance, just log that we'll use the auth from disk
-    if (authState.skipBrowserAuth) {
-      log('Authentication was completed by another instance - will use tokens from disk')
-      // TODO: remove, the callback is happening before the tokens are exchanged
-      //  so we're slightly too early
-      await new Promise((res) => setTimeout(res, 1_000))
-    }
-
     return {
       waitForAuthCode: authState.waitForAuthCode,
       skipBrowserAuth: authState.skipBrowserAuth,


### PR DESCRIPTION
Fixes #322.

When two instances start with no cached token, the secondary waits out the primary, then blocks forever. The host times it out after 60s and the server reads as broken.

**The hang.** `coordinateAuth` hands a secondary a `waitForAuthCode` that is `new Promise(() => {})`. `connectToRemoteServer` used `skipBrowserAuth` only to pick a log line, then awaited it anyway. It now returns early and reconnects, so the auth provider re-reads the tokens the sibling wrote.

**`invalid_grant`.** The `REASON_AUTH_NEEDED` guard was checked *after* `finishAuth`. Since the callback server retains its `authCode`, a second round trip re-exchanged the same single-use code (RFC 6749 4.1.2) and failed with `invalid_grant`, masking the intended `Already attempted reconnection. Giving up.` Guard now runs before the exchange.

**The token-write race.** `waitForAuthentication` resolves when the primary's callback *fires*, which is earlier than the exchange completing and the tokens landing. Both entrypoints papered over this with `await setTimeout(1_000)` and a `TODO`. Replaced with `waitForTokensFromPrimary`, which polls for the file; if the tokens never arrive the secondary now takes over the flow instead of proceeding with credentials that do not exist.

Also makes the secondary's `waitForAuthCode` reject rather than hang, so any future caller that regresses to awaiting it fails loudly.

## Verification

Each regression test was confirmed to fail against the unfixed code:

```
× reconnects instead of awaiting a code when a sibling completed the sign-in
  → expected Symbol(hung) to be 'connected'
× gives up rather than looping when a sibling instance tokens still do not work
  → Test timed out in 5000ms.
× does not re-exchange a spent authorization code when the retry also fails
  → expected [ 'auth-code-789', 'auth-code-789' ] to deeply equal [ 'auth-code-789' ]
```

Lint clean, 168 tests pass (163 + 5 new).

## Note on #321

PR #321 changes `waitForAuthCode` to null out `authCode` after resolving. On top of the old code that turns the `invalid_grant` crash into a *second* silent hang, so it wants a rebase onto this.