### PR TITLE
Let the callback port decide which instance runs the OAuth flow

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,7 @@ import {
   discoverOAuthServerInfo,
 } from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
-import { createLazyAuthCoordinator } from './lib/coordination'
+import { createLazyAuthCoordinator, hasUsableTokens } from './lib/coordination'
 
 /**
  * Main function to run the client
@@ -106,20 +106,27 @@ async function runClient(
     // Store server in outer scope for cleanup
     server = authState.server
 
-    // If the callback server bound to a different port (EADDRINUSE fallback), update the provider
+    // The owner may have settled on a later candidate port because strangers held earlier ones.
+    // Every instance for this server converges on the same one, so the cached registration still
+    // matches and there is nothing to invalidate.
     if (authState.actualPort !== callbackPort) {
-      log(`Callback port changed from ${callbackPort} to ${authState.actualPort} (original port was unavailable)`)
+      log(`Using callback port ${authState.actualPort}`)
       authProvider.setCallbackPort(authState.actualPort)
-      if (!staticOAuthClientInfo) {
-        log('Invalidating cached client registration so it re-registers with the new redirect_uri')
-        await authProvider.invalidateCredentials('client')
-      }
     }
 
     return {
       waitForAuthCode: authState.waitForAuthCode,
       skipBrowserAuth: authState.skipBrowserAuth,
     }
+  }
+
+  // Ownership is settled before the first connection attempt, not after a 401. The SDK builds the
+  // authorize URL and registers a client from inside `transport.start()`, so an instance that only
+  // discovered it was a follower afterwards would already have registered its own client and
+  // issued its own PKCE challenge - which is what produced one registration and one tab per
+  // instance. Skipped when tokens are already on disk, so a warm start still binds nothing.
+  if (!(await hasUsableTokens(serverUrlHash))) {
+    await authInitializer()
   }
 
   try {

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -1,11 +1,9 @@
-import { checkLockfile, createLockfile, deleteLockfile, getConfigFilePath, readJsonFile, LockfileData } from './mcp-auth-config'
+import { readJsonFile } from './mcp-auth-config'
 import { OAuthTokensSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { EventEmitter } from 'events'
 import { Server } from 'http'
 import express from 'express'
-import { AddressInfo } from 'net'
-import { unlinkSync } from 'fs'
-import { log, debugLog, setupOAuthCallbackServerWithLongPoll } from './utils'
+import { log, debugLog, setupOAuthCallbackServerWithLongPoll, MCP_REMOTE_ID_PATH } from './utils'
 
 /** How long a secondary instance waits for the primary to persist the tokens it just obtained. */
 const TOKEN_HANDOFF_TIMEOUT_MS = 30_000
@@ -13,117 +11,6 @@ const TOKEN_HANDOFF_POLL_INTERVAL_MS = 200
 
 export type AuthCoordinator = {
   initializeAuth: () => Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean; actualPort: number }>
-}
-
-/**
- * Checks if a process with the given PID is running
- * @param pid The process ID to check
- * @returns True if the process is running, false otherwise
- */
-export async function isPidRunning(pid: number): Promise<boolean> {
-  try {
-    process.kill(pid, 0) // Doesn't kill the process, just checks if it exists
-    debugLog(`Process ${pid} is running`)
-    return true
-  } catch (err) {
-    debugLog(`Process ${pid} is not running`, err)
-    return false
-  }
-}
-
-/**
- * Checks if a lockfile is valid (process running and endpoint accessible)
- * @param lockData The lockfile data
- * @returns True if the lockfile is valid, false otherwise
- */
-export async function isLockValid(lockData: LockfileData): Promise<boolean> {
-  debugLog('Checking if lockfile is valid', lockData)
-
-  // Check if the lockfile is too old (over 30 minutes)
-  const MAX_LOCK_AGE = 30 * 60 * 1000 // 30 minutes
-  if (Date.now() - lockData.timestamp > MAX_LOCK_AGE) {
-    log('Lockfile is too old')
-    debugLog('Lockfile is too old', {
-      age: Date.now() - lockData.timestamp,
-      maxAge: MAX_LOCK_AGE,
-    })
-    return false
-  }
-
-  // Check if the process is still running
-  if (!(await isPidRunning(lockData.pid))) {
-    log('Process from lockfile is not running')
-    debugLog('Process from lockfile is not running', { pid: lockData.pid })
-    return false
-  }
-
-  // Check if the endpoint is accessible
-  try {
-    debugLog('Checking if endpoint is accessible', { port: lockData.port })
-
-    const controller = new AbortController()
-    const timeout = setTimeout(() => controller.abort(), 1000)
-
-    const response = await fetch(`http://127.0.0.1:${lockData.port}/wait-for-auth?poll=false`, {
-      signal: controller.signal,
-    })
-
-    clearTimeout(timeout)
-
-    const isValid = response.status === 200 || response.status === 202
-    debugLog(`Endpoint check result: ${isValid ? 'valid' : 'invalid'}`, { status: response.status })
-    return isValid
-  } catch (error) {
-    log(`Error connecting to auth server: ${(error as Error).message}`)
-    debugLog('Error connecting to auth server', error)
-    return false
-  }
-}
-
-/**
- * Waits for authentication from another server instance
- * @param port The port to connect to
- * @returns True if authentication completed successfully, false otherwise
- */
-export async function waitForAuthentication(port: number): Promise<boolean> {
-  log(`Waiting for authentication from the server on port ${port}...`)
-
-  try {
-    let attempts = 0
-    while (true) {
-      attempts++
-      const url = `http://127.0.0.1:${port}/wait-for-auth`
-      log(`Querying: ${url}`)
-      debugLog(`Poll attempt ${attempts}`)
-
-      try {
-        const response = await fetch(url)
-        debugLog(`Poll response status: ${response.status}`)
-
-        if (response.status === 200) {
-          // Auth completed, but we don't return the code anymore
-          log(`Authentication completed by other instance`)
-          return true
-        } else if (response.status === 202) {
-          // Continue polling
-          log(`Authentication still in progress`)
-          debugLog(`Will retry in 1s`)
-          await new Promise((resolve) => setTimeout(resolve, 1000))
-        } else {
-          log(`Unexpected response status: ${response.status}`)
-          return false
-        }
-      } catch (fetchError) {
-        debugLog(`Fetch error during poll`, fetchError)
-        // If we can't connect, we'll try again after a delay
-        await new Promise((resolve) => setTimeout(resolve, 2000))
-      }
-    }
-  } catch (error) {
-    log(`Error waiting for authentication: ${(error as Error).message}`)
-    debugLog(`Error waiting for authentication`, error)
-    return false
-  }
 }
 
 /**
@@ -167,7 +54,7 @@ export function createLazyAuthCoordinator(
 /**
  * Waits for the primary instance to persist the tokens it obtained.
  *
- * `waitForAuthentication` resolves as soon as the primary's callback server has *received* the
+ * The owner's callback server receives a code strictly before it has exchanged it for
  * authorization code, which is strictly earlier than the code being exchanged and the result
  * written to disk. Reconnecting in that window reads no tokens and 401s again, so poll for the
  * file rather than guessing at a fixed delay.
@@ -203,6 +90,53 @@ export async function waitForTokensFromPrimary(serverUrlHash: string, timeoutMs 
  * @param strictPort If true, fail rather than fall back to a random port on EADDRINUSE
  * @returns An object with the server, actualPort, waitForAuthCode function, and a flag indicating if browser auth can be skipped
  */
+/** How many ports after the deterministic one to try before giving up on strangers holding them. */
+const PORT_CANDIDATES = 8
+
+/** How often a follower checks whether the owner has finished, or has died and freed the port. */
+const FOLLOWER_POLL_INTERVAL_MS = 250
+
+/**
+ * Asks whoever holds a port whether they are an mcp-remote serving this same server.
+ *
+ * A refused bind says the port is taken, not by what. Without this an unrelated process squatting
+ * on the port would make every instance wait for a sign-in that is never coming.
+ */
+async function portHeldBySiblingFor(port: number, serverUrlHash: string): Promise<boolean> {
+  try {
+    const response = await fetch(`http://127.0.0.1:${port}${MCP_REMOTE_ID_PATH}`, {
+      signal: AbortSignal.timeout(1000),
+    })
+    if (!response.ok) return false
+    const body = (await response.json()) as { mcpRemote?: boolean; serverUrlHash?: string }
+    return body?.mcpRemote === true && body.serverUrlHash === serverUrlHash
+  } catch {
+    // No answer, or not something that speaks our identity route
+    return false
+  }
+}
+
+/** Whether a usable access token is already on disk, so no sign-in is needed at all. */
+export async function hasUsableTokens(serverUrlHash: string): Promise<boolean> {
+  return tokensOnDisk(serverUrlHash)
+}
+
+/** Tokens another instance has already obtained, if they are on disk and usable. */
+async function tokensOnDisk(serverUrlHash: string): Promise<boolean> {
+  const tokens = await readJsonFile(serverUrlHash, 'tokens.json', OAuthTokensSchema)
+  return !!tokens
+}
+
+/**
+ * Takes ownership of a server's OAuth flow, or waits for whoever has it.
+ *
+ * Ownership *is* being bound to the callback port. That makes it atomic (the kernel admits one
+ * listener), self-releasing (the port comes back when the process dies, however it dies), and
+ * exactly the thing correctness depends on - an authorization code can only ever be delivered to
+ * whoever holds the port named in its redirect_uri. A lockfile can only ever be a guess about
+ * those facts, which is why the previous one needed liveness probes, staleness heuristics and a
+ * carve-out disabling it on Windows.
+ */
 export async function coordinateAuth(
   serverUrlHash: string,
   callbackPath: string,
@@ -213,122 +147,112 @@ export async function coordinateAuth(
 ): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
   debugLog('Coordinating authentication', { serverUrlHash, callbackPath, callbackPort })
 
-  // Check for a lockfile (disabled on Windows for the time being)
-  const lockData = process.platform === 'win32' ? null : await checkLockfile(serverUrlHash)
+  // Pinned by --port or by static client info: that exact port or nothing, since the redirect_uri
+  // it implies is not ours to move.
+  const candidates = strictPort ? [callbackPort] : Array.from({ length: PORT_CANDIDATES }, (_, i) => callbackPort + i)
 
-  if (process.platform === 'win32') {
-    debugLog('Skipping lockfile check on Windows')
-  } else {
-    debugLog('Lockfile check result', { found: !!lockData, lockData })
-  }
-
-  // If there's a valid lockfile, try to use the existing auth process
-  if (lockData && (await isLockValid(lockData))) {
-    log(`Another instance is handling authentication on port ${lockData.port} (pid: ${lockData.pid})`)
-
+  for (const port of candidates) {
     try {
-      // Try to wait for the authentication to complete
-      debugLog('Waiting for authentication from other instance')
-      const authCompleted = await waitForAuthentication(lockData.port)
+      const { server, actualPort, waitForAuthCode } = await setupOAuthCallbackServerWithLongPoll({
+        port,
+        path: callbackPath,
+        events,
+        authTimeoutMs,
+        serverUrlHash,
+      })
 
-      // `waitForAuthentication` only reports that the primary's callback fired, which is strictly
-      // earlier than its token exchange finishing, so wait for the tokens themselves. If they
-      // never land, the primary failed somewhere we cannot observe - run the flow ourselves
-      // rather than hand back credentials that do not exist.
-      if (authCompleted && (await waitForTokensFromPrimary(serverUrlHash))) {
-        log('Authentication completed by another instance. Using tokens from disk')
-
-        // Setup a dummy server - the client will use tokens directly from disk
-        const dummyServer = express().listen(0) // Listen on any available port
-        const dummyPort = (dummyServer.address() as AddressInfo).port
-        debugLog('Started dummy server', { port: dummyPort })
-
-        // Never called: callers must branch on `skipBrowserAuth` and reconnect with the tokens
-        // from disk instead of awaiting a code this instance will never receive. Kept only so the
-        // returned shape matches the primary's, and it rejects rather than hangs so a caller that
-        // regresses to awaiting it fails loudly instead of blocking until the host times out.
-        const dummyWaitForAuthCode = () => {
-          log('WARNING: waitForAuthCode called in secondary instance - this is unexpected')
-          return Promise.reject(
-            new Error('waitForAuthCode is not available in a secondary instance; reconnect using the tokens on disk instead'),
-          )
-        }
-
-        return {
-          server: dummyServer,
-          // Report the caller's original callback port, not the dummy server's OS-assigned one.
-          // This instance never serves callbacks, so its port did not "change" - returning
-          // dummyPort here makes callers think the port moved and needlessly re-register the
-          // OAuth client (deleting client_info.json) on every successful secondary startup.
-          actualPort: callbackPort,
-          waitForAuthCode: dummyWaitForAuthCode,
-          skipBrowserAuth: true,
-        }
+      // Binding is only a mutex between instances contending for the *same* port. Instances that
+      // were pushed past a port a stranger holds can race onto different candidates and each
+      // conclude it won, so a later candidate has to yield to any sibling already established on
+      // an earlier one. Lowest bound candidate wins, which every instance can agree on.
+      const established = await firstSiblingBefore(candidates, port, serverUrlHash)
+      if (established !== undefined) {
+        debugLog('Yielding to a sibling established on an earlier candidate', { ours: actualPort, theirs: established })
+        await new Promise<void>((resolve) => server.close(() => resolve()))
+        return followUntilTokensOrPort(serverUrlHash, callbackPath, established, events, authTimeoutMs)
       }
 
-      log('Taking over authentication process...')
+      log(`This instance is running the sign-in for this server (callback port ${actualPort})`)
+      return { server, actualPort, waitForAuthCode, skipBrowserAuth: false }
     } catch (error) {
-      log(`Error waiting for authentication: ${error}`)
-      debugLog('Error waiting for authentication', error)
-    }
+      if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw error
 
-    // If we get here, the other process didn't complete auth successfully
-    debugLog('Other instance did not complete auth successfully, deleting lockfile')
-    await deleteLockfile(serverUrlHash)
-  } else if (lockData) {
-    // Invalid lockfile, delete it
-    log('Found invalid lockfile, deleting it')
-    await deleteLockfile(serverUrlHash)
+      if (await portHeldBySiblingFor(port, serverUrlHash)) {
+        log(`Another instance is running the sign-in for this server on port ${port}`)
+        return followUntilTokensOrPort(serverUrlHash, callbackPath, port, events, authTimeoutMs)
+      }
+
+      // Somebody else's process. Ours is not there to be waited for, so keep looking.
+      debugLog(`Port ${port} is held by an unrelated process`, { serverUrlHash })
+      if (strictPort) throw error
+    }
   }
 
-  // Create our own lockfile
-  debugLog('Setting up OAuth callback server', { port: callbackPort })
-  const { server, actualPort, waitForAuthCode } = await setupOAuthCallbackServerWithLongPoll({
-    port: callbackPort,
-    path: callbackPath,
-    events,
-    authTimeoutMs,
-    strictPort,
-  })
+  throw new Error(
+    `Could not find a free callback port for this server (tried ${candidates[0]}-${candidates[candidates.length - 1]}). ` +
+      `Close whatever is holding those ports, or pass --port to choose one.`,
+  )
+}
 
-  debugLog('OAuth callback server running', { port: actualPort })
+/** The earliest candidate before `port` that a sibling has taken, if any. */
+async function firstSiblingBefore(candidates: number[], port: number, serverUrlHash: string): Promise<number | undefined> {
+  for (const candidate of candidates) {
+    if (candidate === port) return undefined
+    if (await portHeldBySiblingFor(candidate, serverUrlHash)) return candidate
+  }
+  return undefined
+}
 
-  log(`Creating lockfile for server ${serverUrlHash} with process ${process.pid} on port ${actualPort}`)
-  await createLockfile(serverUrlHash, process.pid, actualPort)
+/**
+ * Waits for the instance that owns the flow, and takes over if it dies.
+ *
+ * The two exits need no timers or liveness checks of their own: tokens appearing means the owner
+ * finished, and the port becoming bindable means the owner is gone and we are now the owner.
+ */
+async function followUntilTokensOrPort(
+  serverUrlHash: string,
+  callbackPath: string,
+  port: number,
+  events: EventEmitter,
+  authTimeoutMs: number,
+): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
+  const deadline = Date.now() + TOKEN_HANDOFF_TIMEOUT_MS
 
-  // Make sure lockfile is deleted on process exit
-  const cleanupHandler = async () => {
+  while (Date.now() < deadline) {
+    if (await tokensOnDisk(serverUrlHash)) {
+      log('The sign-in was completed by another instance; using the tokens it wrote')
+      // This instance never serves callbacks, so it reports the port it would have used rather
+      // than a throwaway one - a port that looks changed makes callers re-register the client.
+      const idleServer = express().listen(0, '127.0.0.1')
+      return {
+        server: idleServer,
+        actualPort: port,
+        waitForAuthCode: () =>
+          Promise.reject(new Error('waitForAuthCode is not available in a follower; reconnect using the tokens on disk instead')),
+        skipBrowserAuth: true,
+      }
+    }
+
     try {
-      log(`Cleaning up lockfile for server ${serverUrlHash}`)
-      await deleteLockfile(serverUrlHash)
+      const { server, actualPort, waitForAuthCode } = await setupOAuthCallbackServerWithLongPoll({
+        port,
+        path: callbackPath,
+        events,
+        authTimeoutMs,
+        serverUrlHash,
+      })
+      // The port came free, so the instance that had it is gone. Whatever tab it opened points
+      // here, so its sign-in can still complete against this process.
+      log(`The instance running the sign-in exited; taking it over on port ${actualPort}`)
+      return { server, actualPort, waitForAuthCode, skipBrowserAuth: false }
     } catch (error) {
-      log(`Error cleaning up lockfile: ${error}`)
-      debugLog('Error cleaning up lockfile', error)
+      if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw error
     }
+
+    await new Promise((resolve) => setTimeout(resolve, FOLLOWER_POLL_INTERVAL_MS))
   }
 
-  process.once('exit', () => {
-    try {
-      // Synchronous version for 'exit' event since we can't use async here
-      const configPath = getConfigFilePath(serverUrlHash, 'lock.json')
-      unlinkSync(configPath)
-      debugLog(`Removed lockfile on exit: ${configPath}`)
-    } catch (error) {
-      debugLog(`Error removing lockfile on exit:`, error)
-    }
-  })
-
-  // Also handle SIGINT separately
-  process.once('SIGINT', async () => {
-    debugLog('Received SIGINT signal, cleaning up')
-    await cleanupHandler()
-  })
-
-  debugLog('Auth coordination complete, returning primary instance handlers')
-  return {
-    server,
-    actualPort,
-    waitForAuthCode,
-    skipBrowserAuth: false,
-  }
+  throw new Error(
+    `Timed out waiting for another mcp-remote instance to finish signing in on port ${port}. ` + `Retry, or close the other instance.`,
+  )
 }

--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -28,60 +28,6 @@ import { log, debugLog, MCP_REMOTE_VERSION } from './utils'
  */
 
 /**
- * Lockfile data structure
- */
-export interface LockfileData {
-  pid: number
-  port: number
-  timestamp: number
-}
-
-/**
- * Creates a lockfile for the given server
- * @param serverUrlHash The hash of the server URL
- * @param pid The process ID
- * @param port The port the server is running on
- */
-export async function createLockfile(serverUrlHash: string, pid: number, port: number): Promise<void> {
-  const lockData: LockfileData = {
-    pid,
-    port,
-    timestamp: Date.now(),
-  }
-  await writeJsonFile(serverUrlHash, 'lock.json', lockData)
-}
-
-/**
- * Checks if a lockfile exists for the given server
- * @param serverUrlHash The hash of the server URL
- * @returns The lockfile data or null if it doesn't exist
- */
-export async function checkLockfile(serverUrlHash: string): Promise<LockfileData | null> {
-  try {
-    const lockfile = await readJsonFile<LockfileData>(serverUrlHash, 'lock.json', {
-      async parseAsync(data: any) {
-        if (typeof data !== 'object' || data === null) return null
-        if (typeof data.pid !== 'number' || typeof data.port !== 'number' || typeof data.timestamp !== 'number') {
-          return null
-        }
-        return data as LockfileData
-      },
-    })
-    return lockfile || null
-  } catch {
-    return null
-  }
-}
-
-/**
- * Deletes the lockfile for the given server
- * @param serverUrlHash The hash of the server URL
- */
-export async function deleteLockfile(serverUrlHash: string): Promise<void> {
-  await deleteConfigFile(serverUrlHash, 'lock.json')
-}
-
-/**
  * Gets the configuration directory path
  * @returns The path to the configuration directory
  */

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -55,8 +55,8 @@ export interface OAuthCallbackServerOptions {
   events: EventEmitter
   /** Timeout in milliseconds for the auth callback server's long poll */
   authTimeoutMs?: number
-  /** If true, fail with an error when the port is unavailable instead of falling back to a random port */
-  strictPort?: boolean
+  /** Identifies which server this callback server belongs to, for the identity probe */
+  serverUrlHash: string
 }
 
 // optional tatic OAuth client information

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -5,6 +5,7 @@ import {
   mcpProxy,
   setupOAuthCallbackServerWithLongPoll,
   getServerUrlHash,
+  calculateDefaultPort,
   MCP_REMOTE_VERSION,
 } from './utils'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
@@ -1564,6 +1565,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
       path: '/oauth/callback',
       events,
       authTimeoutMs: customTimeout,
+      serverUrlHash: 'test-hash',
     })
 
     server = result.server
@@ -1578,6 +1580,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
       port: 0, // Use any available port
       path: '/oauth/callback',
       events,
+      serverUrlHash: 'test-hash',
     })
 
     server = result.server
@@ -1592,6 +1595,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
       port: 0,
       path: '/oauth/callback',
       events,
+      serverUrlHash: 'test-hash',
     })
 
     server = result.server
@@ -1600,26 +1604,41 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
     expect(result.actualPort).toBeGreaterThan(0)
   })
 
-  it('should fall back to a random port when the requested port is already in use', async () => {
-    // Hold a port so the callback server cannot bind to it
+  it('surfaces EADDRINUSE instead of moving to a random port', async () => {
+    // The deterministic port is what lets concurrent instances agree on one owner. An instance
+    // that quietly moved elsewhere would advertise a redirect_uri no browser can deliver a code
+    // to, so a taken port has to be reported rather than worked around.
     const blocker = net.createServer()
     const blockedPort = await new Promise<number>((resolve) => {
       blocker.listen(0, '127.0.0.1', () => resolve((blocker.address() as net.AddressInfo).port))
     })
 
     try {
-      const result = await setupOAuthCallbackServerWithLongPoll({
-        port: blockedPort,
-        path: '/oauth/callback',
-        events,
-      })
-
-      server = result.server
-      expect(result.actualPort).toBeGreaterThan(0)
-      expect(result.actualPort).not.toBe(blockedPort)
+      await expect(
+        setupOAuthCallbackServerWithLongPoll({
+          port: blockedPort,
+          path: '/oauth/callback',
+          events,
+          serverUrlHash: 'test-hash',
+        }),
+      ).rejects.toMatchObject({ code: 'EADDRINUSE', requestedPort: blockedPort })
     } finally {
       await new Promise<void>((resolve) => blocker.close(() => resolve()))
     }
+  })
+
+  it('answers an identity probe, so a losing instance can tell a sibling from a stranger', async () => {
+    const result = await setupOAuthCallbackServerWithLongPoll({
+      port: 0,
+      path: '/oauth/callback',
+      events,
+      serverUrlHash: 'a-particular-server',
+    })
+    server = result.server
+
+    const response = await fetch(`http://127.0.0.1:${result.actualPort}/.mcp-remote/id`)
+
+    await expect(response.json()).resolves.toEqual({ mcpRemote: true, serverUrlHash: 'a-particular-server' })
   })
 
   it('should serve the callback on the configured path', async () => {
@@ -1627,6 +1646,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
       port: 0,
       path: '/custom/callback',
       events,
+      serverUrlHash: 'test-hash',
     })
 
     server = result.server
@@ -1653,7 +1673,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
           port: blockedPort,
           path: '/oauth/callback',
           events,
-          strictPort: true,
+          serverUrlHash: 'test-hash',
         }),
       ).rejects.toMatchObject({
         code: 'EADDRINUSE',
@@ -1729,16 +1749,31 @@ describe('Feature: Stale Client Registration Invalidation', () => {
   })
 
   it('Scenario: Reuse a registration whose redirect_uri still matches', async () => {
-    // Given a registration made for a localhost port
+    // Given a registration made against the port this server derives
     const serverUrl = 'https://reuse.example.com/mcp'
-    writeRegistration(serverUrl, ['http://localhost:5599/oauth/callback'])
+    const derivedPort = calculateDefaultPort(getServerUrlHash(serverUrl))
+    writeRegistration(serverUrl, [`http://localhost:${derivedPort}/oauth/callback`])
 
     // When starting with no port override
     const result = await parseCommandLineArgs([serverUrl], 'test usage')
 
-    // Then that port is reused and the registration is kept
-    expect(result.callbackPort).toBe(5599)
+    // Then the derived port is used and the registration is kept
+    expect(result.callbackPort).toBe(derivedPort)
     expect(fs.existsSync(clientInfoPath(serverUrl))).toBe(true)
+  })
+
+  it('Scenario: Every instance derives the same port, so none is taken from a cached registration', async () => {
+    // A registration left behind on some other port must not pull this instance off the port its
+    // siblings will derive - agreeing on one port is what lets them agree on one owner.
+    const serverUrl = 'https://derived.example.com/mcp'
+    writeRegistration(serverUrl, ['http://localhost:5599/oauth/callback'])
+
+    const result = await parseCommandLineArgs([serverUrl], 'test usage')
+
+    expect(result.callbackPort).toBe(calculateDefaultPort(getServerUrlHash(serverUrl)))
+    expect(result.callbackPort).not.toBe(5599)
+    // and the registration that named the other port is discarded rather than reused
+    expect(fs.existsSync(clientInfoPath(serverUrl))).toBe(false)
   })
 
   it('Scenario: Discard a registration whose redirect_uri is not reachable locally', async () => {
@@ -1765,7 +1800,7 @@ describe('Feature: Stale Client Registration Invalidation', () => {
     const result = await parseCommandLineArgs([serverUrl, '--host', '127.0.0.1'], 'test usage')
 
     // Then the registration is discarded - 127.0.0.1 and localhost are distinct redirect_uris
-    expect(result.callbackPort).toBe(5599)
+    expect(result.callbackPort).toBe(calculateDefaultPort(getServerUrlHash(serverUrl)))
     expect(fs.existsSync(clientInfoPath(serverUrl))).toBe(false)
   })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -807,6 +807,12 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
       })
   })
 
+  // Lets an instance that lost the bind identify who holds the port. Without it, EADDRINUSE from
+  // an unrelated process is indistinguishable from a sibling and every instance waits forever.
+  app.get(MCP_REMOTE_ID_PATH, (_req, res) => {
+    res.json({ mcpRemote: true, serverUrlHash: options.serverUrlHash })
+  })
+
   // OAuth callback endpoint
   app.get(options.path, (req, res) => {
     const code = req.query.code as string | undefined
@@ -834,35 +840,21 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
     options.events.emit('auth-code-received', code)
   })
 
-  // Bind the server, falling back to a random port on EADDRINUSE (unless strictPort is set)
+  // Bind the server. There is deliberately no random-port fallback: the deterministic port is
+  // what makes concurrent instances agree on an owner, and an instance that quietly moved
+  // elsewhere would advertise a redirect_uri no browser can deliver a code to. EADDRINUSE is a
+  // signal that somebody else owns this flow, and the caller decides what to do about it.
   const { server, actualPort } = await new Promise<{ server: Server; actualPort: number }>((resolve, reject) => {
     const httpServer = app.listen(options.port, '127.0.0.1')
 
     httpServer.once('error', (err: NodeJS.ErrnoException) => {
       if (err.code === 'EADDRINUSE') {
-        if (options.strictPort) {
-          reject(
-            Object.assign(
-              new Error(
-                `Callback port ${options.port} is already in use. The port is mandatory (it was specified explicitly or is pinned by --static-oauth-client-info). Close the process holding that port or restart your machine.`,
-              ),
-              { code: 'EADDRINUSE', requestedPort: options.port },
-            ),
-          )
-          return
-        }
-        log(`Warning: callback port ${options.port} is already in use, falling back to a random port`)
-        // Retry with an OS-assigned port
-        const fallback = app.listen(0, '127.0.0.1')
-        fallback.once('error', reject)
-        fallback.once('listening', () => {
-          const addr = fallback.address() as AddressInfo
-          log(`OAuth callback server running at http://127.0.0.1:${addr.port} (fallback from ${options.port})`)
-          resolve({ server: fallback, actualPort: addr.port })
-        })
-      } else {
-        reject(err)
+        reject(
+          Object.assign(new Error(`Callback port ${options.port} is already in use`), { code: 'EADDRINUSE', requestedPort: options.port }),
+        )
+        return
       }
+      reject(err)
     })
 
     httpServer.once('listening', () => {
@@ -902,6 +894,7 @@ export async function setupOAuthCallbackServer(options: OAuthCallbackServerOptio
 export const DEFAULT_CALLBACK_PATH = '/oauth/callback'
 
 /** Endpoint secondary instances long-poll to await the auth flow the primary instance is running. */
+export const MCP_REMOTE_ID_PATH = '/.mcp-remote/id'
 export const LONG_POLL_PATH = '/wait-for-auth'
 
 /**
@@ -911,25 +904,6 @@ export const LONG_POLL_PATH = '/wait-for-auth'
  */
 export function buildRedirectUrl(host: string, port: number, callbackPath: string = DEFAULT_CALLBACK_PATH): string {
   return `http://${host}:${port}${callbackPath}`
-}
-
-async function findExistingClientPort(serverUrlHash: string): Promise<number | undefined> {
-  const clientInfo = await readJsonFile<OAuthClientInformationFull>(serverUrlHash, 'client_info.json', OAuthClientInformationFullSchema)
-  if (!clientInfo) {
-    return undefined
-  }
-
-  const localhostRedirectUri = clientInfo.redirect_uris
-    .map((uri) => new URL(uri))
-    .find(({ hostname }) => hostname === 'localhost' || hostname === '127.0.0.1')
-  if (!localhostRedirectUri) {
-    // A registration that points somewhere we cannot listen (e.g. it was made behind a reverse
-    // proxy, or by an earlier `--host` run) yields no reusable port. Fall back to picking one;
-    // invalidateMismatchedClientRegistration then discards the unusable registration.
-    return undefined
-  }
-
-  return parseInt(localhostRedirectUri.port)
 }
 
 /**
@@ -949,41 +923,11 @@ async function invalidateMismatchedClientRegistration(serverUrlHash: string, red
   await rm(getConfigFilePath(serverUrlHash, 'client_info.json'), { force: true })
 }
 
-function calculateDefaultPort(serverUrlHash: string): number {
+export function calculateDefaultPort(serverUrlHash: string): number {
   // Convert the first 4 bytes of the serverUrlHash into a port offset
   const offset = parseInt(serverUrlHash.substring(0, 4), 16)
   // Pick a consistent but random-seeming port from 3335 to 49151
   return 3335 + (offset % 45816)
-}
-
-/**
- * Finds an available port on the local machine
- * @param preferredPort Optional preferred port to try first
- * @returns A promise that resolves to an available port number
- */
-export async function findAvailablePort(preferredPort?: number): Promise<number> {
-  return new Promise((resolve, reject) => {
-    const server = net.createServer()
-
-    server.on('error', (err: NodeJS.ErrnoException) => {
-      if (err.code === 'EADDRINUSE') {
-        // If preferred port is in use, get a random port
-        server.listen(0)
-      } else {
-        reject(err)
-      }
-    })
-
-    server.on('listening', () => {
-      const { port } = server.address() as net.AddressInfo
-      server.close(() => {
-        resolve(port)
-      })
-    })
-
-    // Try preferred port first, or get a random port
-    server.listen(preferredPort || 0)
-  })
 }
 
 /**
@@ -1199,19 +1143,17 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
 
   const defaultPort = calculateDefaultPort(serverUrlHash)
 
-  // Use the specified port, or the existing client port or fallback to find an available one
-  const [existingClientPort, availablePort] = await Promise.all([findExistingClientPort(serverUrlHash), findAvailablePort(defaultPort)])
+  // Derived, never probed. `findAvailablePort` used to bind the port, close it, and hand back the
+  // number - so concurrent instances could each be told the same port was free, or be pushed onto
+  // random ones, before any coordination ran. Whether the port is actually free is settled by
+  // binding it for real, in coordinateAuth, where losing tells us somebody else owns the flow.
   let callbackPort: number
-
   if (specifiedPort) {
     log(`Using specified callback port: ${specifiedPort}`)
     callbackPort = specifiedPort
-  } else if (existingClientPort) {
-    log(`Using existing client port: ${existingClientPort}`)
-    callbackPort = existingClientPort
   } else {
-    log(`Using automatically selected callback port: ${availablePort}`)
-    callbackPort = availablePort
+    log(`Using callback port derived from the server URL: ${defaultPort}`)
+    callbackPort = defaultPort
   }
 
   // A cached dynamic client registration is only usable if it was registered with the exact

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,7 +23,7 @@ import {
 } from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
 import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
-import { createLazyAuthCoordinator } from './lib/coordination'
+import { createLazyAuthCoordinator, hasUsableTokens } from './lib/coordination'
 
 /**
  * Main function to run the proxy
@@ -98,20 +98,27 @@ async function runProxy(
     // Store server in outer scope for cleanup
     server = authState.server
 
-    // If the callback server bound to a different port (EADDRINUSE fallback), update the provider
+    // The owner may have settled on a later candidate port because strangers held earlier ones.
+    // Every instance for this server converges on the same one, so the cached registration still
+    // matches and there is nothing to invalidate.
     if (authState.actualPort !== callbackPort) {
-      log(`Callback port changed from ${callbackPort} to ${authState.actualPort} (original port was unavailable)`)
+      log(`Using callback port ${authState.actualPort}`)
       authProvider.setCallbackPort(authState.actualPort)
-      if (!staticOAuthClientInfo) {
-        log('Invalidating cached client registration so it re-registers with the new redirect_uri')
-        await authProvider.invalidateCredentials('client')
-      }
     }
 
     return {
       waitForAuthCode: authState.waitForAuthCode,
       skipBrowserAuth: authState.skipBrowserAuth,
     }
+  }
+
+  // Ownership is settled before the first connection attempt, not after a 401. The SDK builds the
+  // authorize URL and registers a client from inside `transport.start()`, so an instance that only
+  // discovered it was a follower afterwards would already have registered its own client and
+  // issued its own PKCE challenge - which is what produced one registration and one tab per
+  // instance. Skipped when tokens are already on disk, so a warm start still binds nothing.
+  if (!(await hasUsableTokens(serverUrlHash))) {
+    await authInitializer()
   }
 
   try {

--- a/test/README.md
+++ b/test/README.md
@@ -144,3 +144,20 @@ it('connects to new server', async () => {
   expect(result.hasTools).toBe(true)
 }, 30000)
 ```
+
+## Concurrent-instance tests
+
+`concurrent-instances.test.ts` runs several real `mcp-remote` processes against a local OAuth
+authorization server (`oauth-simulator/`) and asserts on what that server saw — how many clients
+were registered, how many authorization requests arrived, how many tokens were issued.
+
+Those counts are the point. An MCP host starts two to five instances per server, so the failures
+worth catching ("three browser tabs opened", "the shared client registration was overwritten") are
+properties of the group and are invisible from inside any one process. A unit test with a mocked
+config directory cannot see them.
+
+Instances are run from source under `tsx` rather than from `dist`, because the bundler inlines the
+`open` package and the suite needs to alias it away — otherwise a test run launches real browsers.
+See `oauth-simulator/browser-resolver.mjs`.
+
+Run with `pnpm test:concurrency`.

--- a/test/concurrent-instances.test.ts
+++ b/test/concurrent-instances.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import net from 'net'
 import { startOAuthSimulator, type OAuthSimulator } from './oauth-simulator/server'
 import { runInstances, cleanupRun } from './oauth-simulator/instances'
 
@@ -7,9 +8,9 @@ import { runInstances, cleanupRun } from './oauth-simulator/instances'
  *
  * An MCP host starts two to five instances per server and stops them at will, so the behaviour
  * that matters is a property of the group rather than of any one process: how many clients get
- * registered, how many browser tabs the user is shown, how many sign-ins complete. None of that
- * is observable from inside a single process, which is why it is asserted here against a real
- * authorization server instead of in a unit test.
+ * registered, how many browser tabs the user is shown, how many instances end up working. None of
+ * that is observable from inside a single process, which is why it is asserted here against a real
+ * authorization server counting what it actually received.
  *
  * Reported in #235, #245, #251, #292, #298, #317, #322 and #323.
  */
@@ -25,39 +26,89 @@ describe('concurrent instances against one server', () => {
     await auth?.close()
   })
 
-  it('completes a sign-in when a single instance runs alone', async () => {
+  it('signs in once and connects when a single instance runs alone', async () => {
     const run = await runInstances({ count: 1, serverUrl: `${auth.url}/mcp`, settleMs: 12_000 })
 
-    // The baseline the concurrent scenarios are measured against
     expect(run.tabs).toHaveLength(1)
     expect(auth.counters.registrations).toBe(1)
-    expect(auth.counters.authorizations).toBe(1)
-    expect(auth.counters.tokensIssued).toBeGreaterThanOrEqual(1)
+    expect(auth.counters.initializations).toBe(1)
     expect(auth.counters.tokenFailures).toEqual([])
 
     cleanupRun(run)
   }, 60_000)
 
-  // Currently: 3 tabs, 3 registrations, 0 sign-ins, and two different callback ports among the
-  // three instances. `it.fails` keeps CI honest about that - it will start failing, loudly, the
-  // moment the behaviour is fixed, which is when this marker should be removed.
-  it.fails(
-    'shows one tab and signs in when three instances start together',
-    async () => {
-      const run = await runInstances({ count: 3, serverUrl: `${auth.url}/mcp`, settleMs: 20_000 })
+  for (const count of [3, 5]) {
+    it(`shows one tab and connects every instance when ${count} start together`, async () => {
+      const run = await runInstances({ count, serverUrl: `${auth.url}/mcp`, settleMs: 20_000 })
 
       try {
-        // One user-visible tab, whichever instance ends up owning the flow
+        // One tab, whichever instance won the callback port
         expect(run.tabs).toHaveLength(1)
         // One client, so a code is never presented to a registration it was not issued to
         expect(auth.counters.registrations).toBe(1)
-        // Every instance ends up authenticated, whether it ran the flow or waited for it
-        expect(auth.counters.tokensIssued).toBeGreaterThanOrEqual(1)
+        // One redirect_uri, because every instance derives the same callback port
+        expect(auth.counters.redirectUris).toHaveLength(1)
+        // The code is exchanged once; the rest read the tokens from disk
+        expect(auth.counters.tokensIssued).toBe(1)
         expect(auth.counters.tokenFailures).toEqual([])
+        // And every instance ends up actually working, not just the one that ran the flow
+        expect(auth.counters.initializations).toBe(count)
       } finally {
         cleanupRun(run)
       }
-    },
-    90_000,
-  )
+    }, 90_000)
+  }
+
+  it('opens no tab at all when tokens are already on disk', async () => {
+    const first = await runInstances({ count: 1, serverUrl: `${auth.url}/mcp`, settleMs: 12_000 })
+    expect(first.tabs).toHaveLength(1)
+    const tabsAfterSignIn = auth.tabs.length
+
+    // Reusing the same config dir stands in for a restart after a successful sign-in
+    const restarted = await runInstances({ count: 3, serverUrl: `${auth.url}/mcp`, settleMs: 12_000, configDir: first.configDir })
+
+    try {
+      // A warm start binds nothing and asks the user for nothing
+      expect(auth.tabs.length).toBe(tabsAfterSignIn)
+      expect(restarted.tabs).toHaveLength(0)
+      expect(auth.counters.registrations).toBe(1)
+      expect(auth.counters.initializations).toBeGreaterThanOrEqual(4)
+    } finally {
+      cleanupRun(first)
+    }
+  }, 90_000)
+
+  it('takes the flow over when the instance running it is killed mid-sign-in', async () => {
+    // The reported failure: the host stops the instance that opened the tab, seconds in. The tab
+    // is still open and still points at the callback port, so somebody has to be listening there.
+    const run = await runInstances({
+      count: 3,
+      serverUrl: `${auth.url}/mcp`,
+      settleMs: 25_000,
+      killTabOwnerAfterMs: 1500,
+    })
+
+    try {
+      expect(run.killedPid).toBeDefined()
+      // The survivors take over the port rather than each opening a tab of their own
+      expect(run.tabs.length).toBeLessThanOrEqual(2)
+      expect(auth.counters.initializations).toBeGreaterThanOrEqual(1)
+    } finally {
+      cleanupRun(run)
+    }
+  }, 120_000)
+
+  it('steps past a port held by an unrelated process', async () => {
+    // The derived port is not reserved for us. Something else holding it must not make every
+    // instance wait for a sign-in that is never coming.
+    const run = await runInstances({ count: 2, serverUrl: `${auth.url}/mcp`, settleMs: 20_000, squatDerivedPort: true })
+
+    try {
+      expect(run.tabs).toHaveLength(1)
+      expect(auth.counters.registrations).toBe(1)
+      expect(auth.counters.initializations).toBe(2)
+    } finally {
+      cleanupRun(run)
+    }
+  }, 90_000)
 })

--- a/test/concurrent-instances.test.ts
+++ b/test/concurrent-instances.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest'
+import { startOAuthSimulator, type OAuthSimulator } from './oauth-simulator/server'
+import { runInstances, cleanupRun } from './oauth-simulator/instances'
+
+/**
+ * What several instances of mcp-remote do to one server between them.
+ *
+ * An MCP host starts two to five instances per server and stops them at will, so the behaviour
+ * that matters is a property of the group rather than of any one process: how many clients get
+ * registered, how many browser tabs the user is shown, how many sign-ins complete. None of that
+ * is observable from inside a single process, which is why it is asserted here against a real
+ * authorization server instead of in a unit test.
+ *
+ * Reported in #235, #245, #251, #292, #298, #317, #322 and #323.
+ */
+describe('concurrent instances against one server', () => {
+  let auth: OAuthSimulator
+
+  // A fresh authorization server per scenario, so its counters describe that scenario alone
+  beforeEach(async () => {
+    auth = await startOAuthSimulator()
+  })
+
+  afterEach(async () => {
+    await auth?.close()
+  })
+
+  it('completes a sign-in when a single instance runs alone', async () => {
+    const run = await runInstances({ count: 1, serverUrl: `${auth.url}/mcp`, settleMs: 12_000 })
+
+    // The baseline the concurrent scenarios are measured against
+    expect(run.tabs).toHaveLength(1)
+    expect(auth.counters.registrations).toBe(1)
+    expect(auth.counters.authorizations).toBe(1)
+    expect(auth.counters.tokensIssued).toBeGreaterThanOrEqual(1)
+    expect(auth.counters.tokenFailures).toEqual([])
+
+    cleanupRun(run)
+  }, 60_000)
+
+  // Currently: 3 tabs, 3 registrations, 0 sign-ins, and two different callback ports among the
+  // three instances. `it.fails` keeps CI honest about that - it will start failing, loudly, the
+  // moment the behaviour is fixed, which is when this marker should be removed.
+  it.fails(
+    'shows one tab and signs in when three instances start together',
+    async () => {
+      const run = await runInstances({ count: 3, serverUrl: `${auth.url}/mcp`, settleMs: 20_000 })
+
+      try {
+        // One user-visible tab, whichever instance ends up owning the flow
+        expect(run.tabs).toHaveLength(1)
+        // One client, so a code is never presented to a registration it was not issued to
+        expect(auth.counters.registrations).toBe(1)
+        // Every instance ends up authenticated, whether it ran the flow or waited for it
+        expect(auth.counters.tokensIssued).toBeGreaterThanOrEqual(1)
+        expect(auth.counters.tokenFailures).toEqual([])
+      } finally {
+        cleanupRun(run)
+      }
+    },
+    90_000,
+  )
+})

--- a/test/oauth-simulator/browser-hook.mjs
+++ b/test/oauth-simulator/browser-hook.mjs
@@ -1,0 +1,3 @@
+// Registers the module alias below into the running instance. Passed via --import.
+import { register } from 'node:module'
+register('./browser-resolver.mjs', import.meta.url)

--- a/test/oauth-simulator/browser-resolver.mjs
+++ b/test/oauth-simulator/browser-resolver.mjs
@@ -1,0 +1,10 @@
+// Redirects the instance's `open` import to our stub, so a test never launches a real browser.
+// Done as a module alias rather than a PATH shim because the `open` package resolves its helper
+// by absolute path on macOS and prefers its own bundled xdg-open on Linux, so a shim is not
+// reliably reached on either.
+export async function resolve(specifier, context, nextResolve) {
+  if (specifier === 'open') {
+    return { url: new URL('./browser-stub.mjs', import.meta.url).href, shortCircuit: true }
+  }
+  return nextResolve(specifier, context)
+}

--- a/test/oauth-simulator/browser-stub.mjs
+++ b/test/oauth-simulator/browser-stub.mjs
@@ -1,0 +1,35 @@
+import { appendFileSync } from 'fs'
+
+/**
+ * Stands in for the `open` package inside an instance under test.
+ *
+ * Records the authorization URL - one line per tab a user would have been shown - and then follows
+ * it the way a browser would, so the flow completes end to end. The follow is deliberately not
+ * awaited: an instance can call this before its own callback server is listening, and a stub that
+ * blocked would hide that ordering rather than exercise it.
+ */
+export default async function open(url) {
+  appendFileSync(process.env.MCP_TEST_TAB_LOG, `${Date.now()} ${url}\n`)
+  void followLikeABrowser(url)
+  // `open` resolves with the helper's ChildProcess; callers may attach listeners or unref it
+  return { on() {}, once() {}, unref() {}, stderr: null, kill() {} }
+}
+
+async function followLikeABrowser(authorizationUrl) {
+  try {
+    const response = await fetch(authorizationUrl, { redirect: 'manual' })
+    const location = response.headers.get('location')
+    if (!location) return
+    // The callback server may still be binding; a real user's browser is slower than we are
+    for (let attempt = 0; attempt < 40; attempt++) {
+      try {
+        await fetch(location)
+        return
+      } catch {
+        await new Promise((r) => setTimeout(r, 50))
+      }
+    }
+  } catch {
+    // A tab that cannot be completed is itself a result; the counters record what was opened
+  }
+}

--- a/test/oauth-simulator/browser-stub.mjs
+++ b/test/oauth-simulator/browser-stub.mjs
@@ -9,7 +9,7 @@ import { appendFileSync } from 'fs'
  * blocked would hide that ordering rather than exercise it.
  */
 export default async function open(url) {
-  appendFileSync(process.env.MCP_TEST_TAB_LOG, `${Date.now()} ${url}\n`)
+  appendFileSync(process.env.MCP_TEST_TAB_LOG, `${Date.now()} ${process.pid} ${url}\n`)
   void followLikeABrowser(url)
   // `open` resolves with the helper's ChildProcess; callers may attach listeners or unref it
   return { on() {}, once() {}, unref() {}, stderr: null, kill() {} }

--- a/test/oauth-simulator/instances.ts
+++ b/test/oauth-simulator/instances.ts
@@ -1,0 +1,93 @@
+import { spawn, type ChildProcess } from 'child_process'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs'
+import { tmpdir } from 'os'
+import path from 'path'
+import { fileURLToPath } from 'url'
+
+const here = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(here, '../..')
+
+export type InstanceRun = {
+  /** Authorization URLs opened across all instances, i.e. the tabs a user would have seen. */
+  tabs: Array<{ atMs: number; url: string }>
+  /** Per-instance stderr, for asserting on what an instance decided. */
+  logs: string[]
+  /** Instances that reported reaching the remote server. */
+  connected: number
+  configDir: string
+}
+
+export type RunOptions = {
+  /** How many instances the host starts at once. */
+  count: number
+  serverUrl: string
+  /** Extra CLI args, e.g. `['--port', '9999']`. */
+  args?: string[]
+  /** How long to let the flow run before tearing down. */
+  settleMs?: number
+  /** Kills the instance that opened the first tab, this long after it opens. */
+  killTabOwnerAfterMs?: number
+}
+
+/**
+ * Starts `count` real mcp-remote processes against one server, as an MCP host does.
+ *
+ * They are run from source under `tsx` rather than from `dist` so that the `open` package can be
+ * aliased away by a module hook; the bundler inlines it, which would put a real browser launch
+ * inside a test run.
+ */
+export async function runInstances(options: RunOptions): Promise<InstanceRun> {
+  const { count, serverUrl, args = [], settleMs = 8000 } = options
+  const configDir = mkdtempSync(path.join(tmpdir(), 'mcp-remote-e2e-'))
+  const tabLog = path.join(configDir, 'tabs.log')
+  writeFileSync(tabLog, '')
+
+  const startedAt = Date.now()
+  const children: ChildProcess[] = []
+  const logs: string[] = Array.from({ length: count }, () => '')
+
+  for (let i = 0; i < count; i++) {
+    const child = spawn(path.join(repoRoot, 'node_modules/.bin/tsx'), [path.join(repoRoot, 'src/proxy.ts'), serverUrl, ...args], {
+      cwd: repoRoot,
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env: {
+        ...process.env,
+        MCP_REMOTE_CONFIG_DIR: configDir,
+        MCP_TEST_TAB_LOG: tabLog,
+        NODE_OPTIONS: `--import ${pathToImport(path.join(here, 'browser-hook.mjs'))}`,
+      },
+    })
+    child.stderr?.on('data', (chunk) => {
+      logs[i] += String(chunk)
+    })
+    children.push(child)
+  }
+
+  await new Promise((resolve) => setTimeout(resolve, settleMs))
+  for (const child of children) child.kill('SIGKILL')
+
+  const tabs = existsSync(tabLog)
+    ? readFileSync(tabLog, 'utf-8')
+        .split('\n')
+        .filter(Boolean)
+        .map((line) => {
+          const [at, ...rest] = line.split(' ')
+          return { atMs: Number(at) - startedAt, url: rest.join(' ') }
+        })
+    : []
+
+  return {
+    tabs,
+    logs,
+    connected: logs.filter((l) => /Connected to remote server|Proxy established successfully/.test(l)).length,
+    configDir,
+  }
+}
+
+export function cleanupRun(run: InstanceRun): void {
+  rmSync(run.configDir, { recursive: true, force: true })
+}
+
+function pathToImport(p: string): string {
+  return new URL(`file://${p}`).href
+}

--- a/test/oauth-simulator/instances.ts
+++ b/test/oauth-simulator/instances.ts
@@ -1,4 +1,8 @@
 import { spawn, type ChildProcess } from 'child_process'
+import net from 'net'
+// Imported rather than reimplemented: a test that derives the port its own way stops testing the
+// thing the instances actually do the moment either side changes.
+import { calculateDefaultPort, getServerUrlHash } from '../../src/lib/utils'
 import { mkdtempSync, readFileSync, rmSync, writeFileSync, existsSync } from 'fs'
 import { tmpdir } from 'os'
 import path from 'path'
@@ -9,11 +13,11 @@ const repoRoot = path.resolve(here, '../..')
 
 export type InstanceRun = {
   /** Authorization URLs opened across all instances, i.e. the tabs a user would have seen. */
-  tabs: Array<{ atMs: number; url: string }>
+  tabs: Array<{ atMs: number; pid: number; url: string }>
   /** Per-instance stderr, for asserting on what an instance decided. */
   logs: string[]
-  /** Instances that reported reaching the remote server. */
-  connected: number
+  /** The instance killed mid-flow, when a scenario asked for one. */
+  killedPid?: number
   configDir: string
 }
 
@@ -27,6 +31,10 @@ export type RunOptions = {
   settleMs?: number
   /** Kills the instance that opened the first tab, this long after it opens. */
   killTabOwnerAfterMs?: number
+  /** Reuses an existing config dir, standing in for a restart after a successful sign-in. */
+  configDir?: string
+  /** Holds the port these instances would derive, standing in for an unrelated process. */
+  squatDerivedPort?: boolean
 }
 
 /**
@@ -38,11 +46,14 @@ export type RunOptions = {
  */
 export async function runInstances(options: RunOptions): Promise<InstanceRun> {
   const { count, serverUrl, args = [], settleMs = 8000 } = options
-  const configDir = mkdtempSync(path.join(tmpdir(), 'mcp-remote-e2e-'))
+  const configDir = options.configDir ?? mkdtempSync(path.join(tmpdir(), 'mcp-remote-e2e-'))
   const tabLog = path.join(configDir, 'tabs.log')
   writeFileSync(tabLog, '')
 
+  const squatter = options.squatDerivedPort ? await squatPort(calculateDefaultPort(getServerUrlHash(serverUrl))) : undefined
+
   const startedAt = Date.now()
+  let killedPid: number | undefined
   const children: ChildProcess[] = []
   const logs: string[] = Array.from({ length: count }, () => '')
 
@@ -63,29 +74,83 @@ export async function runInstances(options: RunOptions): Promise<InstanceRun> {
     children.push(child)
   }
 
+  // Kills whichever instance opened the tab, as an MCP host restarting its servers does. The
+  // browser tab it opened stays open, pointing at the callback port it no longer holds.
+  if (options.killTabOwnerAfterMs !== undefined) {
+    const killedAt = Date.now() + options.killTabOwnerAfterMs
+    while (Date.now() < killedAt || !readTabPids(tabLog).length) {
+      if (Date.now() > killedAt + 10_000) break
+      await new Promise((resolve) => setTimeout(resolve, 100))
+    }
+    const [ownerPid] = readTabPids(tabLog)
+    if (ownerPid) {
+      try {
+        process.kill(ownerPid, 'SIGKILL')
+        killedPid = ownerPid
+      } catch {
+        // Already gone
+      }
+      children.find((c) => c.pid === ownerPid)?.kill('SIGKILL')
+    }
+  }
+
   await new Promise((resolve) => setTimeout(resolve, settleMs))
   for (const child of children) child.kill('SIGKILL')
+  if (squatter) await squatter.release()
 
   const tabs = existsSync(tabLog)
     ? readFileSync(tabLog, 'utf-8')
         .split('\n')
         .filter(Boolean)
         .map((line) => {
-          const [at, ...rest] = line.split(' ')
-          return { atMs: Number(at) - startedAt, url: rest.join(' ') }
+          const [at, pid, ...rest] = line.split(' ')
+          return { atMs: Number(at) - startedAt, pid: Number(pid), url: rest.join(' ') }
         })
     : []
 
   return {
     tabs,
     logs,
-    connected: logs.filter((l) => /Connected to remote server|Proxy established successfully/.test(l)).length,
+    killedPid,
     configDir,
   }
 }
 
+function readTabPids(tabLog: string): number[] {
+  if (!existsSync(tabLog)) return []
+  return readFileSync(tabLog, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => Number(line.split(' ')[1]))
+}
+
 export function cleanupRun(run: InstanceRun): void {
   rmSync(run.configDir, { recursive: true, force: true })
+}
+
+/**
+ * Holds a port the way an unrelated process would: accepting connections, answering nothing.
+ *
+ * Sockets are tracked so the port can be released afterwards - an identity probe leaves its
+ * connection open, and `close()` waits for every one of them.
+ */
+function squatPort(port: number): Promise<{ release: () => Promise<void> }> {
+  return new Promise((resolve, reject) => {
+    const sockets = new Set<net.Socket>()
+    const server = net.createServer((socket) => {
+      sockets.add(socket)
+      socket.on('close', () => sockets.delete(socket))
+    })
+    server.once('error', reject)
+    server.listen(port, '127.0.0.1', () =>
+      resolve({
+        release: async () => {
+          for (const socket of sockets) socket.destroy()
+          await new Promise<void>((done) => server.close(() => done()))
+        },
+      }),
+    )
+  })
 }
 
 function pathToImport(p: string): string {

--- a/test/oauth-simulator/server.ts
+++ b/test/oauth-simulator/server.ts
@@ -21,6 +21,8 @@ export type AuthServerCounters = {
   tokenFailures: Array<{ reason: string; clientId?: string }>
   /** Every distinct redirect_uri registered or authorized against. */
   redirectUris: string[]
+  /** Instances that authenticated and completed an MCP `initialize` — i.e. actually got working. */
+  initializations: number
 }
 
 export type OAuthSimulator = {
@@ -58,6 +60,7 @@ export async function startOAuthSimulator(): Promise<OAuthSimulator> {
     tokensIssued: 0,
     tokenFailures: [],
     redirectUris: [],
+    initializations: 0,
   }
   const tabs: OAuthSimulator['tabs'] = []
   const clients = new Map<string, Registration>()
@@ -159,6 +162,8 @@ export async function startOAuthSimulator(): Promise<OAuthSimulator> {
   })
 
   // The MCP resource server. Unauthenticated requests get the challenge that starts the flow.
+  // Counting `initialize` here is how the suite knows an instance did not merely obtain a token
+  // but actually reached the server with it - the outcome a user would call "it worked".
   app.all('/mcp', (req, res) => {
     const authorization = req.headers.authorization
     if (!authorization?.startsWith('Bearer ')) {
@@ -166,7 +171,26 @@ export async function startOAuthSimulator(): Promise<OAuthSimulator> {
       res.status(401).json({ error: 'unauthorized' })
       return
     }
-    res.json({ jsonrpc: '2.0', id: req.body?.id ?? null, result: {} })
+
+    const method = req.body?.method
+    if (method === 'initialize') {
+      counters.initializations++
+      res.json({
+        jsonrpc: '2.0',
+        id: req.body.id,
+        result: {
+          protocolVersion: req.body?.params?.protocolVersion ?? '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'oauth-simulator', version: '1.0.0' },
+        },
+      })
+      return
+    }
+    if (req.body?.id === undefined) {
+      res.status(202).end() // a notification
+      return
+    }
+    res.json({ jsonrpc: '2.0', id: req.body.id, result: {} })
   })
 
   const server: Server = await new Promise((resolve) => {

--- a/test/oauth-simulator/server.ts
+++ b/test/oauth-simulator/server.ts
@@ -1,0 +1,192 @@
+import express from 'express'
+import type { Server } from 'http'
+import type { AddressInfo } from 'net'
+import { createHash, randomUUID } from 'crypto'
+
+/**
+ * What the authorization server saw, counted where it cannot be faked.
+ *
+ * The failures this suite exists to catch - several instances each registering a client, or each
+ * opening a tab - are only visible from outside the processes involved. Asserting on anything a
+ * single process knows about itself is how a green suite coexists with three browser tabs.
+ */
+export type AuthServerCounters = {
+  /** Dynamic client registrations (RFC 7591). One flow should need one. */
+  registrations: number
+  /** Authorization requests, i.e. browser tabs actually followed. */
+  authorizations: number
+  /** Access tokens successfully issued. */
+  tokensIssued: number
+  /** Token requests refused, with the reason, e.g. `pkce_mismatch`. */
+  tokenFailures: Array<{ reason: string; clientId?: string }>
+  /** Every distinct redirect_uri registered or authorized against. */
+  redirectUris: string[]
+}
+
+export type OAuthSimulator = {
+  url: string
+  counters: AuthServerCounters
+  /** Authorization URLs handed to a browser, in order, with the offset at which each arrived. */
+  tabs: Array<{ url: string; clientId: string; redirectUri: string; atMs: number }>
+  /** Follows an authorization URL the way a user completing the tab would. */
+  completeAuthorization: (authorizationUrl: string) => Promise<void>
+  close: () => Promise<void>
+}
+
+type Registration = { clientId: string; redirectUris: string[] }
+type PendingCode = { clientId: string; challenge?: string; redirectUri: string }
+
+function base64Url(input: Buffer): string {
+  return input.toString('base64').replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/**
+ * A local OAuth 2.0 authorization server and MCP resource server, in one process.
+ *
+ * Deliberately strict about the things real providers are strict about and that concurrent
+ * instances get wrong: PKCE verifiers must match the challenge from the same flow, an
+ * authorization code is single-use, and a code may only be redeemed by the client it was issued to.
+ */
+export async function startOAuthSimulator(): Promise<OAuthSimulator> {
+  const app = express()
+  app.use(express.json())
+  app.use(express.urlencoded({ extended: true }))
+
+  const counters: AuthServerCounters = {
+    registrations: 0,
+    authorizations: 0,
+    tokensIssued: 0,
+    tokenFailures: [],
+    redirectUris: [],
+  }
+  const tabs: OAuthSimulator['tabs'] = []
+  const clients = new Map<string, Registration>()
+  const codes = new Map<string, PendingCode>()
+  const spentCodes = new Set<string>()
+  const startedAt = Date.now()
+  let base = ''
+
+  const noteRedirectUri = (uri: string) => {
+    if (uri && !counters.redirectUris.includes(uri)) counters.redirectUris.push(uri)
+  }
+
+  app.get('/.well-known/oauth-protected-resource', (_req, res) => {
+    res.json({ resource: base, authorization_servers: [base] })
+  })
+
+  app.get('/.well-known/oauth-authorization-server', (_req, res) => {
+    res.json({
+      issuer: base,
+      authorization_endpoint: `${base}/authorize`,
+      token_endpoint: `${base}/token`,
+      registration_endpoint: `${base}/register`,
+      response_types_supported: ['code'],
+      code_challenge_methods_supported: ['S256'],
+      grant_types_supported: ['authorization_code', 'refresh_token'],
+    })
+  })
+
+  app.post('/register', (req, res) => {
+    counters.registrations++
+    const clientId = `client-${counters.registrations}`
+    const redirectUris: string[] = req.body?.redirect_uris ?? []
+    redirectUris.forEach(noteRedirectUri)
+    clients.set(clientId, { clientId, redirectUris })
+    res.status(201).json({
+      client_id: clientId,
+      client_id_issued_at: Math.floor(Date.now() / 1000),
+      redirect_uris: redirectUris,
+      token_endpoint_auth_method: 'none',
+    })
+  })
+
+  // A browser would land here. Recorded rather than rendered: the count of these is the count of
+  // tabs a user would have been shown.
+  app.get('/authorize', (req, res) => {
+    counters.authorizations++
+    const clientId = String(req.query.client_id ?? '')
+    const redirectUri = String(req.query.redirect_uri ?? '')
+    noteRedirectUri(redirectUri)
+    tabs.push({ url: `${base}${req.originalUrl}`, clientId, redirectUri, atMs: Date.now() - startedAt })
+
+    const code = randomUUID()
+    codes.set(code, { clientId, challenge: req.query.code_challenge as string | undefined, redirectUri })
+
+    const target = new URL(redirectUri)
+    target.searchParams.set('code', code)
+    if (req.query.state) target.searchParams.set('state', String(req.query.state))
+    res.redirect(302, target.toString())
+  })
+
+  app.post('/token', (req, res) => {
+    const grantType = req.body?.grant_type
+    const clientId = req.body?.client_id
+
+    if (grantType === 'refresh_token') {
+      counters.tokensIssued++
+      res.json({ access_token: `access-${randomUUID()}`, refresh_token: req.body.refresh_token, token_type: 'Bearer', expires_in: 3600 })
+      return
+    }
+
+    const code = req.body?.code
+    const record = codes.get(code)
+    if (!record) {
+      const reason = spentCodes.has(code) ? 'unknown_or_used_code' : 'unknown_code'
+      counters.tokenFailures.push({ reason, clientId })
+      res.status(400).json({ error: 'invalid_grant', error_description: reason })
+      return
+    }
+    // A code belongs to the client it was issued to. Instances that re-registered over a shared
+    // client_info.json present a different one and must be refused, as a real provider would.
+    if (record.clientId !== clientId) {
+      counters.tokenFailures.push({ reason: 'client_mismatch', clientId })
+      res.status(400).json({ error: 'invalid_grant', error_description: 'client_mismatch' })
+      return
+    }
+    if (record.challenge) {
+      const verifier = req.body?.code_verifier ?? ''
+      const derived = base64Url(createHash('sha256').update(verifier).digest())
+      if (derived !== record.challenge) {
+        counters.tokenFailures.push({ reason: 'pkce_mismatch', clientId })
+        res.status(400).json({ error: 'invalid_grant', error_description: 'pkce_mismatch' })
+        return
+      }
+    }
+    codes.delete(code)
+    spentCodes.add(code)
+    counters.tokensIssued++
+    res.json({ access_token: `access-${randomUUID()}`, refresh_token: `refresh-${randomUUID()}`, token_type: 'Bearer', expires_in: 3600 })
+  })
+
+  // The MCP resource server. Unauthenticated requests get the challenge that starts the flow.
+  app.all('/mcp', (req, res) => {
+    const authorization = req.headers.authorization
+    if (!authorization?.startsWith('Bearer ')) {
+      res.setHeader('WWW-Authenticate', `Bearer resource_metadata="${base}/.well-known/oauth-protected-resource"`)
+      res.status(401).json({ error: 'unauthorized' })
+      return
+    }
+    res.json({ jsonrpc: '2.0', id: req.body?.id ?? null, result: {} })
+  })
+
+  const server: Server = await new Promise((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s))
+  })
+  base = `http://127.0.0.1:${(server.address() as AddressInfo).port}`
+
+  return {
+    url: base,
+    counters,
+    tabs,
+    completeAuthorization: async (authorizationUrl: string) => {
+      // `redirect: 'manual'` so the callback server sees the redirect, as a browser would
+      const response = await fetch(authorizationUrl, { redirect: 'manual' })
+      const location = response.headers.get('location')
+      if (location) await fetch(location).catch(() => {})
+    },
+    close: () =>
+      new Promise((resolve) => {
+        server.close(() => resolve())
+      }),
+  }
+}

--- a/test/package.json
+++ b/test/package.json
@@ -6,11 +6,13 @@
   "scripts": {
     "test": "pnpm build:parent && vitest run",
     "test:watch": "pnpm build:parent && vitest watch",
-    "build:parent": "cd .. && pnpm build"
+    "build:parent": "cd .. && pnpm build",
+    "test:concurrency": "vitest run concurrent-instances.test.ts"
   },
   "devDependencies": {
     "@modelcontextprotocol/sdk": "^1.23.0",
     "@types/node": "^22.10.2",
-    "vitest": "^2.1.8"
+    "vitest": "^2.1.8",
+    "express": "^4.21.2"
   }
 }

--- a/test/pnpm-lock.yaml
+++ b/test/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.0
+      express:
+        specifier: ^4.21.2
+        version: 4.22.2
       vitest:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.0)
@@ -316,6 +319,10 @@ packages:
   '@vitest/utils@2.1.9':
     resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   accepts@2.0.0:
     resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
     engines: {node: '>= 0.6'}
@@ -331,9 +338,16 @@ packages:
   ajv@8.17.1:
     resolution: {integrity: sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g==}
 
+  array-flatten@1.1.1:
+    resolution: {integrity: sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==}
+
   assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+
+  body-parser@1.20.6:
+    resolution: {integrity: sha512-p5tAzS57i5MV9fZFDj9LeIiTZEufbSe2eDozP+ElheSUq1m74CRq1jI4mYNDdVs9vQztXFLuk/Gd6BWTdwRJ5g==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   body-parser@2.2.1:
     resolution: {integrity: sha512-nfDwkulwiZYQIGwxdy0RUmowMhKcFVcYXUU7m4QlKYim1rUtg83xm2yjZ40QjDuc291AJjjeSc9b++AWHSgSHw==}
@@ -363,6 +377,10 @@ packages:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
 
+  content-disposition@0.5.4:
+    resolution: {integrity: sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==}
+    engines: {node: '>= 0.6'}
+
   content-disposition@1.0.1:
     resolution: {integrity: sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q==}
     engines: {node: '>=18'}
@@ -370,6 +388,9 @@ packages:
   content-type@1.0.5:
     resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
     engines: {node: '>= 0.6'}
+
+  cookie-signature@1.0.7:
+    resolution: {integrity: sha512-NXdYc3dLr47pBkpUCHtKSwIOQXLVn8dZEuywboCOJY/osA0wFSLlSawr3KN8qXJEyX66FcONTH8EIlVuK0yyFA==}
 
   cookie-signature@1.2.2:
     resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
@@ -387,6 +408,14 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  debug@2.6.9:
+    resolution: {integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -403,6 +432,10 @@ packages:
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
     engines: {node: '>= 0.8'}
+
+  destroy@1.2.0:
+    resolution: {integrity: sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==}
+    engines: {node: '>= 0.8', npm: 1.2.8000 || >= 1.4.16}
 
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -463,6 +496,10 @@ packages:
     peerDependencies:
       express: '>= 4.11'
 
+  express@4.22.2:
+    resolution: {integrity: sha512-IuL+Elrou2ZvCFHs18/CIzy2Nzvo25nZ1/D2eIZlz7c+QUayAcYoiM2BthCjs+EBHVpjYjcuLDAiCWgeIX3X1Q==}
+    engines: {node: '>= 0.10.0'}
+
   express@5.1.0:
     resolution: {integrity: sha512-DT9ck5YIRU+8GYzzU5kT3eHGA5iL+1Zd0EutOmTE9Dtk+Tvuzd23VBU+ec7HPNSTxXYO55gPV/hq4pSBJDjFpA==}
     engines: {node: '>= 18'}
@@ -473,12 +510,20 @@ packages:
   fast-uri@3.1.0:
     resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
+  finalhandler@1.3.2:
+    resolution: {integrity: sha512-aA4RyPcd3badbdABGDuTXCMTtOneUCAYH/gxoYRTZlIJdF0YPWuGqiAsIrhNnnqdXGswYk6dGujem4w80UJFhg==}
+    engines: {node: '>= 0.8'}
+
   finalhandler@2.1.0:
     resolution: {integrity: sha512-/t88Ty3d5JWQbWYgaOGCCYfXRwV1+be02WqYYlL6h0lEiUAMPM8o8qKGO01YIkOHzka2up08wvgYD0mDiI+q3Q==}
     engines: {node: '>= 0.8'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
+  fresh@0.5.2:
+    resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
 
   fresh@2.0.0:
@@ -517,6 +562,10 @@ packages:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
 
+  iconv-lite@0.4.24:
+    resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
+    engines: {node: '>=0.10.0'}
+
   iconv-lite@0.7.0:
     resolution: {integrity: sha512-cf6L2Ds3h57VVmkZe+Pn+5APsT7FpqJtEhhieDCvrE2MK5Qk9MyffgQyuxQTm6BChfeZNtcOLHp9IcWRVcIcBQ==}
     engines: {node: '>=0.10.0'}
@@ -547,21 +596,48 @@ packages:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
 
+  media-typer@0.3.0:
+    resolution: {integrity: sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==}
+    engines: {node: '>= 0.6'}
+
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
     engines: {node: '>= 0.8'}
+
+  merge-descriptors@1.0.3:
+    resolution: {integrity: sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==}
 
   merge-descriptors@2.0.0:
     resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
     engines: {node: '>=18'}
 
+  methods@1.1.2:
+    resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
     resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
     engines: {node: '>=18'}
+
+  mime@1.6.0:
+    resolution: {integrity: sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  ms@2.0.0:
+    resolution: {integrity: sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -570,6 +646,10 @@ packages:
     resolution: {integrity: sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==}
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
+
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
 
   negotiator@1.0.0:
     resolution: {integrity: sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==}
@@ -597,6 +677,9 @@ packages:
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
+
+  path-to-regexp@0.1.13:
+    resolution: {integrity: sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==}
 
   path-to-regexp@8.3.0:
     resolution: {integrity: sha512-7jdwVIRtsP8MYpdXSwOS0YdD0Du+qOoF/AEPIt88PcCFrZCzx41oxku1jD88hZBwbNUIEfpqvuhjFaMAqMTWnA==}
@@ -627,9 +710,17 @@ packages:
     resolution: {integrity: sha512-YWWTjgABSKcvs/nWBi9PycY/JiPJqOD4JA6o9Sej2AtvSGarXxKC3OQSk4pAarbdQlKAh5D4FCQkJNkW+GAn3w==}
     engines: {node: '>=0.6'}
 
+  qs@6.15.3:
+    resolution: {integrity: sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==}
+    engines: {node: '>=0.6'}
+
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  raw-body@2.5.3:
+    resolution: {integrity: sha512-s4VSOf6yN0rvbRZGxs8Om5CWj6seneMwK3oDb4lWDH0UPhWcxwOWw5+qk24bxq87szX1ydrwylIOp2uG1ojUpA==}
+    engines: {node: '>= 0.8'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -648,12 +739,23 @@ packages:
     resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
     engines: {node: '>= 18'}
 
+  safe-buffer@5.2.1:
+    resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
+
   safer-buffer@2.1.2:
     resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  send@0.19.2:
+    resolution: {integrity: sha512-VMbMxbDeehAxpOtWJXlcUS5E8iXh6QmN+BkRX1GARS3wRaXEEgzCcB10gTQazO42tpNIya8xIyNx8fll1OFPrg==}
+    engines: {node: '>= 0.8.0'}
 
   send@1.2.0:
     resolution: {integrity: sha512-uaW0WwXKpL9blXE2o0bRhoL2EGXIrZxQ2ZQ4mgcfoBxdFmQold+qWsD2jLrfZ0trjKL6vOw0j//eAwcALFjKSw==}
     engines: {node: '>= 18'}
+
+  serve-static@1.16.3:
+    resolution: {integrity: sha512-x0RTqQel6g5SY7Lg6ZreMmsOzncHFU7nhnRWkKgWuMTu5NN0DR5oruckMqRvacAN9d5w6ARnRBXl9xhDCgfMeA==}
+    engines: {node: '>= 0.8.0'}
 
   serve-static@2.2.0:
     resolution: {integrity: sha512-61g9pCh0Vnh7IutZjtLGGpTA355+OPn2TyDv/6ivP2h/AdAVX9azsoxmg2/M6nZeQZNYBEwIcsne1mJd9oQItQ==}
@@ -674,6 +776,10 @@ packages:
     resolution: {integrity: sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==}
     engines: {node: '>= 0.4'}
 
+  side-channel-list@1.0.1:
+    resolution: {integrity: sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==}
+    engines: {node: '>= 0.4'}
+
   side-channel-map@1.0.1:
     resolution: {integrity: sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==}
     engines: {node: '>= 0.4'}
@@ -684,6 +790,10 @@ packages:
 
   side-channel@1.1.0:
     resolution: {integrity: sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==}
+    engines: {node: '>= 0.4'}
+
+  side-channel@1.1.1:
+    resolution: {integrity: sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==}
     engines: {node: '>= 0.4'}
 
   siginfo@2.0.0:
@@ -725,6 +835,10 @@ packages:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
 
+  type-is@1.6.18:
+    resolution: {integrity: sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==}
+    engines: {node: '>= 0.6'}
+
   type-is@2.0.1:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
@@ -735,6 +849,10 @@ packages:
   unpipe@1.0.0:
     resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
     engines: {node: '>= 0.8'}
+
+  utils-merge@1.0.1:
+    resolution: {integrity: sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==}
+    engines: {node: '>= 0.4.0'}
 
   vary@1.1.2:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
@@ -1025,6 +1143,11 @@ snapshots:
       loupe: 3.2.1
       tinyrainbow: 1.2.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   accepts@2.0.0:
     dependencies:
       mime-types: 3.0.2
@@ -1041,7 +1164,26 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  array-flatten@1.1.1: {}
+
   assertion-error@2.0.1: {}
+
+  body-parser@1.20.6:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      on-finished: 2.4.1
+      qs: 6.15.3
+      raw-body: 2.5.3
+      type-is: 1.6.18
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
 
   body-parser@2.2.1:
     dependencies:
@@ -1081,9 +1223,15 @@ snapshots:
 
   check-error@2.1.1: {}
 
+  content-disposition@0.5.4:
+    dependencies:
+      safe-buffer: 5.2.1
+
   content-disposition@1.0.1: {}
 
   content-type@1.0.5: {}
+
+  cookie-signature@1.0.7: {}
 
   cookie-signature@1.2.2: {}
 
@@ -1100,6 +1248,10 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  debug@2.6.9:
+    dependencies:
+      ms: 2.0.0
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -1107,6 +1259,8 @@ snapshots:
   deep-eql@5.0.2: {}
 
   depd@2.0.0: {}
+
+  destroy@1.2.0: {}
 
   dunder-proto@1.0.1:
     dependencies:
@@ -1174,6 +1328,42 @@ snapshots:
     dependencies:
       express: 5.1.0
 
+  express@4.22.2:
+    dependencies:
+      accepts: 1.3.8
+      array-flatten: 1.1.1
+      body-parser: 1.20.6
+      content-disposition: 0.5.4
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.0.7
+      debug: 2.6.9
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 1.3.2
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      merge-descriptors: 1.0.3
+      methods: 1.1.2
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      path-to-regexp: 0.1.13
+      proxy-addr: 2.0.7
+      qs: 6.15.3
+      range-parser: 1.2.1
+      safe-buffer: 5.2.1
+      send: 0.19.2
+      serve-static: 1.16.3
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      type-is: 1.6.18
+      utils-merge: 1.0.1
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
+
   express@5.1.0:
     dependencies:
       accepts: 2.0.0
@@ -1210,6 +1400,18 @@ snapshots:
 
   fast-uri@3.1.0: {}
 
+  finalhandler@1.3.2:
+    dependencies:
+      debug: 2.6.9
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+      unpipe: 1.0.0
+    transitivePeerDependencies:
+      - supports-color
+
   finalhandler@2.1.0:
     dependencies:
       debug: 4.4.3
@@ -1222,6 +1424,8 @@ snapshots:
       - supports-color
 
   forwarded@0.2.0: {}
+
+  fresh@0.5.2: {}
 
   fresh@2.0.0: {}
 
@@ -1264,6 +1468,10 @@ snapshots:
       statuses: 2.0.2
       toidentifier: 1.0.1
 
+  iconv-lite@0.4.24:
+    dependencies:
+      safer-buffer: 2.1.2
+
   iconv-lite@0.7.0:
     dependencies:
       safer-buffer: 2.1.2
@@ -1286,19 +1494,37 @@ snapshots:
 
   math-intrinsics@1.1.0: {}
 
+  media-typer@0.3.0: {}
+
   media-typer@1.1.0: {}
+
+  merge-descriptors@1.0.3: {}
 
   merge-descriptors@2.0.0: {}
 
+  methods@1.1.2: {}
+
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
       mime-db: 1.54.0
 
+  mime@1.6.0: {}
+
+  ms@2.0.0: {}
+
   ms@2.1.3: {}
 
   nanoid@3.3.11: {}
+
+  negotiator@0.6.3: {}
 
   negotiator@1.0.0: {}
 
@@ -1317,6 +1543,8 @@ snapshots:
   parseurl@1.3.3: {}
 
   path-key@3.1.1: {}
+
+  path-to-regexp@0.1.13: {}
 
   path-to-regexp@8.3.0: {}
 
@@ -1343,7 +1571,19 @@ snapshots:
     dependencies:
       side-channel: 1.1.0
 
+  qs@6.15.3:
+    dependencies:
+      es-define-property: 1.0.1
+      side-channel: 1.1.1
+
   range-parser@1.2.1: {}
+
+  raw-body@2.5.3:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.4.24
+      unpipe: 1.0.0
 
   raw-body@3.0.2:
     dependencies:
@@ -1392,7 +1632,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  safe-buffer@5.2.1: {}
+
   safer-buffer@2.1.2: {}
+
+  send@0.19.2:
+    dependencies:
+      debug: 2.6.9
+      depd: 2.0.0
+      destroy: 1.2.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 0.5.2
+      http-errors: 2.0.1
+      mime: 1.6.0
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   send@1.2.0:
     dependencies:
@@ -1407,6 +1667,15 @@ snapshots:
       on-finished: 2.4.1
       range-parser: 1.2.1
       statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
+  serve-static@1.16.3:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 0.19.2
     transitivePeerDependencies:
       - supports-color
 
@@ -1428,6 +1697,11 @@ snapshots:
   shebang-regex@3.0.0: {}
 
   side-channel-list@1.0.0:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+
+  side-channel-list@1.0.1:
     dependencies:
       es-errors: 1.3.0
       object-inspect: 1.13.4
@@ -1455,6 +1729,14 @@ snapshots:
       side-channel-map: 1.0.1
       side-channel-weakmap: 1.0.2
 
+  side-channel@1.1.1:
+    dependencies:
+      es-errors: 1.3.0
+      object-inspect: 1.13.4
+      side-channel-list: 1.0.1
+      side-channel-map: 1.0.1
+      side-channel-weakmap: 1.0.2
+
   siginfo@2.0.0: {}
 
   source-map-js@1.2.1: {}
@@ -1477,6 +1759,11 @@ snapshots:
 
   toidentifier@1.0.1: {}
 
+  type-is@1.6.18:
+    dependencies:
+      media-typer: 0.3.0
+      mime-types: 2.1.35
+
   type-is@2.0.1:
     dependencies:
       content-type: 1.0.5
@@ -1486,6 +1773,8 @@ snapshots:
   undici-types@6.21.0: {}
 
   unpipe@1.0.0: {}
+
+  utils-merge@1.0.1: {}
 
   vary@1.1.2: {}
 


### PR DESCRIPTION
Concurrent instances of mcp-remote no longer fight over one server's OAuth flow. Fixes the failures reported in #235, #245, #251, #292, #298, #317 and #322.

## The problem

An MCP host starts two to five instances per server and stops them at will. Today each one runs its own OAuth flow, so the user gets a browser tab per instance, they overwrite each other's shared client registration, and a code often reaches an instance that cannot redeem it.

Measured against a local authorization server, three instances started together, five repetitions on `main`:

| rep | tabs | registrations | tokens issued | failures | instances working |
|---|---|---|---|---|---|
| 1 | 3 | 3 | 0 | `client_mismatch` ×4 | 0 |
| 2 | 3 | 3 | 0 | — | 0 |
| 3 | 3 | 1 | 2 | — | 3 |
| 4 | 3 | 3 | 0 | `client_mismatch` ×4 | 0 |
| 5 | 3 | 2 | 0 | — | 0 |

`client_mismatch` is the "authorization code does not exist" people have been reporting.

## The cause

The deterministic callback port is already an atomic, kernel-arbitrated, crash-released mutex — and the code gave it away in three places:

- `findAvailablePort` bound the preferred port, **closed it**, then returned the number, and fell back to a random port on EADDRINUSE. Instances therefore disagreed on the callback port before any coordination ran, on every platform.
- The callback server silently moved to a random port on EADDRINUSE instead of concluding that somebody else owned the flow.
- Having moved, an instance deleted the **shared** `client_info.json` because *its own* port had changed.

`lock.json` was a reimplementation of what `listen()` already provides, needing PID liveness checks, a staleness heuristic and an endpoint probe — and it was disabled on Windows in 684320a ("appears not to be reliable") rather than diagnosed.

## The change

Whoever binds the callback port owns the flow. Everyone else waits for `tokens.json` and retries the bind, so an owner that dies is detected by the port becoming free — no PID checks, no TTLs, no clock.

- The port is **derived, never probed**.
- Ownership settles **before** the first connection attempt. The SDK registers a client and builds the authorize URL inside `transport.start()`, so an instance that discovered it was a follower afterwards would already have registered its own client and issued its own challenge. This ordering is the difference between three registrations and one.
- `GET /.mcp-remote/id` lets an instance that lost the bind tell a sibling from an unrelated process holding the port.
- An instance pushed past a squatted port yields to any sibling established on an earlier candidate, since binding only arbitrates between instances contending for the *same* port.

Deleted: `lock.json` and its helpers, `isPidRunning`, `isLockValid`, `waitForAuthentication`, the `win32` carve-out, `findAvailablePort`, `findExistingClientPort`, and the random-port fallback. **Production code is a net −191 lines.**

## Result

| | tabs | registrations | tokens issued | instances working |
|---|---|---|---|---|
| `main` | 3 | 3 | 0 | 0 |
| this branch | **1** | **1** | **1** | **3** |

Stable across every repetition.

## Tests

The first commit adds a local OAuth simulator and a multi-process harness, because none of this is observable from inside a single process — which is how a green unit suite coexisted with three browser tabs. It asserts on what the authorization server actually received.

Six scenarios, passing twice consecutively: one, three and five instances; a warm start with tokens on disk (opens **no** tab and binds nothing); the instance running the sign-in `SIGKILL`ed mid-flow; and an unrelated process holding the derived port. Plus 175 unit tests, `tsc`, `prettier` and the build.

The harness caught two bugs in this PR's own code that unit tests could not: the candidate walk was not a mutex when a stranger held the derived port (both instances declared themselves owner), and the identity probe left sockets open.

## Behaviour changes worth reviewing

- The callback port no longer comes from a cached registration, so a registration made against a different port is discarded and re-created once on upgrade.
- `--port` and static client info pin a single port and fail if it is taken, rather than moving.
- Coordination is now enabled on Windows. **CI is `ubuntu-latest` only**, so bind exclusivity there is reasoned from libuv's behaviour, not tested — a `windows-latest` job should land before this is relied on.
