### PR TITLE
Share one auth flow between 401s that arrive in the same tick

### DIFF
--- a/src/lib/coordination.test.ts
+++ b/src/lib/coordination.test.ts
@@ -3,7 +3,10 @@ import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import { writeJsonFile } from './mcp-auth-config'
-import { waitForTokensFromPrimary } from './coordination'
+import { waitForTokensFromPrimary, createLazyAuthCoordinator } from './coordination'
+import { EventEmitter } from 'events'
+import net from 'net'
+import http from 'http'
 
 describe('Feature: Token handoff between concurrent instances', () => {
   const hash = 'handoff-test'
@@ -39,4 +42,55 @@ describe('Feature: Token handoff between concurrent instances', () => {
     // Then the secondary reports failure instead of blocking forever
     await expect(waitForTokensFromPrimary(hash, 500)).resolves.toBe(false)
   })
+})
+
+describe('Feature: Two 401s arriving in the same tick', () => {
+  let configDir: string
+
+  beforeEach(async () => {
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-remote-lazy-'))
+    process.env.MCP_REMOTE_CONFIG_DIR = configDir
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(async () => {
+    delete process.env.MCP_REMOTE_CONFIG_DIR
+    await fs.rm(configDir, { recursive: true, force: true })
+    vi.restoreAllMocks()
+  })
+
+  it('Scenario: They share one flow instead of racing for the callback port', async () => {
+    // Concurrent re-entry used to slip past a guard that tested the resolved value, so both calls
+    // started a flow and the loser died on an unhandled EADDRINUSE - taking the winner's callback
+    // server down with it (#317).
+    const coordinator = createLazyAuthCoordinator('lazy-shared', '/oauth/callback', 0, new EventEmitter(), 5000)
+
+    const [first, second] = await Promise.all([coordinator.initializeAuth(), coordinator.initializeAuth()])
+
+    // One flow, so there is no second callback server to collide with the first
+    expect(first).toBe(second)
+    first.server.close()
+  })
+
+  it('Scenario: A failed attempt is not cached, so a retry can still succeed', async () => {
+    // Given the port is taken by something that is not us, and pinned, so the attempt must fail
+    const blocker = http.createServer((_req, res) => {
+      res.writeHead(404).end()
+    })
+    const blockedPort = await new Promise<number>((resolve) => {
+      blocker.listen(0, '127.0.0.1', () => resolve((blocker.address() as net.AddressInfo).port))
+    })
+    const coordinator = createLazyAuthCoordinator('lazy-retry', '/oauth/callback', blockedPort, new EventEmitter(), 5000, true)
+
+    await expect(coordinator.initializeAuth()).rejects.toMatchObject({ code: 'EADDRINUSE' })
+
+    // When the port frees up, a retry has to be able to take it - a cached rejection would
+    // replay the original failure forever
+    blocker.closeAllConnections()
+    await new Promise<void>((resolve) => blocker.close(() => resolve()))
+    const retried = await coordinator.initializeAuth()
+
+    expect(retried.actualPort).toBe(blockedPort)
+    retried.server.close()
+  }, 15_000)
 })

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -30,23 +30,37 @@ export function createLazyAuthCoordinator(
   authTimeoutMs: number,
   strictPort = false,
 ): AuthCoordinator {
-  let authState: { server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean; actualPort: number } | null = null
+  // The in-flight promise is what gets shared, not the resolved value. Guarding on the result
+  // only rules out sequential re-entry: two 401s landing in the same tick would both find it
+  // unset and both start a flow, and the loser of the resulting port race used to take the
+  // process down with an unhandled EADDRINUSE (https://github.com/geelen/mcp-remote/issues/317).
+  let authState: Promise<{
+    server: Server
+    waitForAuthCode: () => Promise<string>
+    skipBrowserAuth: boolean
+    actualPort: number
+  }> | null = null
 
   return {
     initializeAuth: async () => {
-      // If auth has already been initialized, return the existing state
       if (authState) {
-        debugLog('Auth already initialized, reusing existing state')
+        debugLog('Auth already initializing or initialized, reusing it')
         return authState
       }
 
       log('Initializing auth coordination on-demand')
       debugLog('Initializing auth coordination on-demand', { serverUrlHash, callbackPort })
 
-      // Initialize auth using the existing coordinateAuth logic
-      authState = await coordinateAuth(serverUrlHash, callbackPath, callbackPort, events, authTimeoutMs, strictPort)
-      debugLog('Auth coordination completed', { skipBrowserAuth: authState.skipBrowserAuth, actualPort: authState.actualPort })
-      return authState
+      authState = coordinateAuth(serverUrlHash, callbackPath, callbackPort, events, authTimeoutMs, strictPort)
+      try {
+        const resolved = await authState
+        debugLog('Auth coordination completed', { skipBrowserAuth: resolved.skipBrowserAuth, actualPort: resolved.actualPort })
+        return resolved
+      } catch (error) {
+        // A failed attempt must not be cached, or every later retry replays the same rejection
+        authState = null
+        throw error
+      }
     },
   }
 }


### PR DESCRIPTION
Closes #317.

#325 fixed the second half of that issue — the unhandled `EADDRINUSE` that took the process down is gone, since a refused bind is now how an instance learns somebody else owns the flow. But the first half was still there:

```ts
if (authState) return authState
authState = await coordinateAuth(...)
```

The guard tests the *resolved* value, so it only rules out sequential re-entry. Two 401s landing in the same tick both find it unset and both start a flow.

Sharing the in-flight promise instead makes the second caller wait on the first. A rejection is not cached, so a retry after the port frees up can still succeed.

Two tests. The concurrency one fails against the previous code (two distinct auth states, i.e. two flows); the retry one is characterization, guarding the new `try/catch`.
