### PR TITLE
Report whether the browser actually opened, and fall back when it did not

### DIFF
--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -1,4 +1,3 @@
-import open from 'open'
 import { z } from 'zod'
 import { OAuthClientProvider, refreshAuthorization, selectResourceURL } from '@modelcontextprotocol/sdk/client/auth.js'
 import {
@@ -9,6 +8,7 @@ import {
 } from '@modelcontextprotocol/sdk/shared/auth.js'
 import type { OAuthProviderOptions, StaticOAuthClientMetadata } from './types'
 import { readJsonFile, writeJsonFile, readTextFile, writeTextFile, deleteConfigFile } from './mcp-auth-config'
+import { openBrowser } from './open-browser'
 import { StaticOAuthClientInformationFull } from './types'
 import { log, debugLog, buildRedirectUrl, MCP_REMOTE_VERSION } from './utils'
 import { sanitizeUrl } from 'strict-url-sanitise'
@@ -417,12 +417,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
     debugLog('Redirecting to authorization URL', authorizationUrl.toString())
 
-    try {
-      await open(sanitizeUrl(authorizationUrl.toString()))
+    if (await openBrowser(sanitizeUrl(authorizationUrl.toString()))) {
       log('Browser opened automatically.')
-    } catch (error) {
-      log('Could not open browser automatically. Please copy and paste the URL above into your browser.')
-      debugLog('Failed to open browser', error)
+    } else {
+      log('Could not open a browser automatically. Please copy and paste the URL above into your browser.')
     }
   }
 

--- a/src/lib/open-browser.test.ts
+++ b/src/lib/open-browser.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import { spawn } from 'child_process'
+import open from 'open'
+import { openBrowser } from './open-browser'
+
+vi.mock('child_process', () => ({ spawn: vi.fn() }))
+vi.mock('open', () => ({ default: vi.fn() }))
+vi.mock('./utils', () => ({ log: vi.fn(), debugLog: vi.fn() }))
+
+/** A helper process that never exits on its own, like a browser in the foreground. */
+const runningHelper = () => new EventEmitter()
+
+/** A helper that exits with the given code, once the caller is listening for it. */
+const exitingHelper = (code: number) => emitsWhenWatched('exit', code)
+
+/** A helper that cannot be started at all. */
+const missingHelper = () => emitsWhenWatched('error', new Error('spawn ENOENT'))
+
+function emitsWhenWatched(event: 'exit' | 'error', payload: unknown) {
+  const child = new EventEmitter()
+  child.on('newListener', (added) => {
+    if (added === event) queueMicrotask(() => child.emit(event, payload))
+  })
+  return child
+}
+
+describe('Feature: Opening the authorization URL', () => {
+  const url = 'https://auth.example.com/authorize'
+
+  beforeEach(() => {
+    vi.mocked(spawn).mockReset()
+    vi.mocked(open).mockReset()
+    Object.defineProperty(process, 'platform', { value: 'linux', configurable: true })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('Scenario: The bundled opener works', async () => {
+    vi.mocked(open).mockResolvedValue(exitingHelper(0) as any)
+
+    await expect(openBrowser(url)).resolves.toBe(true)
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('Scenario: A helper that keeps running is the browser itself', async () => {
+    // x-www-browser is the browser, and a generic xdg-open runs it in the foreground: waiting for
+    // either to exit would block until the user closes their browser.
+    vi.useFakeTimers()
+    vi.mocked(open).mockResolvedValue(runningHelper() as any)
+
+    const opening = openBrowser(url)
+    await vi.advanceTimersByTimeAsync(600)
+
+    await expect(opening).resolves.toBe(true)
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('Scenario: Falling through to a helper that works', async () => {
+    // What a host that runs the proxy without the graphical session variables does
+    vi.mocked(open).mockResolvedValue(exitingHelper(3) as any)
+    vi.mocked(spawn)
+      .mockReturnValueOnce(exitingHelper(3) as any)
+      .mockReturnValueOnce(exitingHelper(0) as any)
+
+    await expect(openBrowser(url)).resolves.toBe(true)
+    expect(vi.mocked(spawn).mock.calls.map(([command]) => command)).toEqual(['/usr/bin/xdg-open', 'gio'])
+  })
+
+  it('Scenario: Nothing can open a browser', async () => {
+    vi.mocked(open).mockResolvedValue(exitingHelper(3) as any)
+    vi.mocked(spawn).mockReturnValue(exitingHelper(3) as any)
+
+    await expect(openBrowser(url)).resolves.toBe(false)
+    expect(spawn).toHaveBeenCalledTimes(4)
+  })
+
+  it('Scenario: A helper that is not installed', async () => {
+    vi.mocked(open).mockRejectedValue(new Error('spawn ENOENT'))
+    vi.mocked(spawn).mockImplementation(() => missingHelper() as any)
+
+    await expect(openBrowser(url)).resolves.toBe(false)
+  })
+})

--- a/src/lib/open-browser.ts
+++ b/src/lib/open-browser.ts
@@ -1,0 +1,90 @@
+import { spawn, type ChildProcess } from 'child_process'
+import open from 'open'
+import { log, debugLog } from './utils'
+
+/** How long a helper is given to fail before we accept that it launched something. */
+const HELPER_SETTLE_MS = 500
+
+/** Helpers to try on Linux, in order, when the bundled opener does not work. */
+const LINUX_FALLBACKS: Array<{ command: string; args: (url: string) => string[] }> = [
+  { command: '/usr/bin/xdg-open', args: (url) => [url] },
+  { command: 'gio', args: (url) => ['open', url] },
+  { command: 'x-www-browser', args: (url) => [url] },
+  { command: 'sensible-browser', args: (url) => [url] },
+]
+
+/**
+ * Reports whether a spawned helper launched anything
+ *
+ * A helper still running once it has had a chance to fail counts as a success: `x-www-browser` is
+ * the browser itself, and a generic `xdg-open` runs it in the foreground, so waiting for either to
+ * exit would block until the user closes their browser.
+ * @param child The spawned helper
+ * @param name The helper's name, for logging
+ * @returns True unless the helper failed to start or exited with a failure
+ */
+function launched(child: ChildProcess, name: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const settle = setTimeout(() => {
+      debugLog(`Browser helper ${name} is still running, treating it as the browser`)
+      resolve(true)
+    }, HELPER_SETTLE_MS)
+    settle.unref?.()
+
+    const settled = (result: boolean) => {
+      clearTimeout(settle)
+      resolve(result)
+    }
+
+    child.once('error', (error) => {
+      debugLog(`Browser helper ${name} failed to start`, error)
+      settled(false)
+    })
+    child.once('exit', (code) => {
+      debugLog(`Browser helper ${name} exited`, { code })
+      settled(code === 0)
+    })
+  })
+}
+
+/**
+ * Opens a URL in the user's browser, falling back through the platform's other openers
+ *
+ * The bundled opener resolves as soon as its helper is spawned, which on a host that runs the
+ * proxy without the graphical session variables reports success while nothing opens.
+ * @param url The URL to open
+ * @returns True if one of the helpers launched something
+ */
+export async function openBrowser(url: string): Promise<boolean> {
+  debugLog('Browser launch environment', {
+    DISPLAY: process.env.DISPLAY,
+    WAYLAND_DISPLAY: process.env.WAYLAND_DISPLAY,
+    DBUS_SESSION_BUS_ADDRESS: process.env.DBUS_SESSION_BUS_ADDRESS ? 'set' : undefined,
+    BROWSER: process.env.BROWSER,
+  })
+
+  try {
+    if (await launched(await open(url), 'open')) {
+      return true
+    }
+  } catch (error) {
+    debugLog('Failed to spawn the bundled opener', error)
+  }
+
+  if (process.platform !== 'linux') {
+    return false
+  }
+
+  for (const fallback of LINUX_FALLBACKS) {
+    try {
+      log(`Trying ${fallback.command} to open the browser...`)
+      if (await launched(spawn(fallback.command, fallback.args(url), { stdio: 'ignore' }), fallback.command)) {
+        return true
+      }
+    } catch (error) {
+      debugLog(`Failed to spawn ${fallback.command}`, error)
+    }
+  }
+
+  return false
+}


### PR DESCRIPTION
Split out of #320 at @punkpeye's request, with both notes from his testing applied.

## The problem

`open()` resolves when its helper is spawned, not when the helper managed to open anything. On a host that runs the proxy without the graphical session variables the log says

```
Browser opened automatically.
```

and nothing appears. The URL is printed above that line, but nothing tells the user it now has to be copied by hand, so the sign-in looks hung rather than waiting on them.


## The change

`openBrowser()` reports whether a helper launched something, and on Linux tries the other openers before giving up: `/usr/bin/xdg-open`, `gio open`, `x-www-browser`, `sensible-browser`. Only when all of them fail does the caller tell the user to copy the URL.