### PR TITLE
Only coordinate a sign-in when the server actually asks for one

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -24,7 +24,7 @@ import {
   discoverOAuthServerInfo,
 } from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
-import { createLazyAuthCoordinator, hasUsableTokens } from './lib/coordination'
+import { createLazyAuthCoordinator, hasUsableTokens, serverIssuesAuthChallenge } from './lib/coordination'
 
 /**
  * Main function to run the client
@@ -125,7 +125,7 @@ async function runClient(
   // discovered it was a follower afterwards would already have registered its own client and
   // issued its own PKCE challenge - which is what produced one registration and one tab per
   // instance. Skipped when tokens are already on disk, so a warm start still binds nothing.
-  if (!(await hasUsableTokens(serverUrlHash))) {
+  if (!(await hasUsableTokens(serverUrlHash)) && (await serverIssuesAuthChallenge(serverUrl, headers))) {
     await authInitializer()
   }
 

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -130,6 +130,30 @@ async function portHeldBySiblingFor(port: number, serverUrlHash: string): Promis
   }
 }
 
+/**
+ * Whether the server answers an unauthenticated request with a challenge.
+ *
+ * Ownership has to be settled before the first connection attempt, because the SDK registers a
+ * client from inside `transport.start()`. But that is only worth doing for a server that actually
+ * wants OAuth: a public one, or one authenticated by `--header`, never writes tokens, so every
+ * instance but the first would wait out the handoff timeout and exit.
+ */
+export async function serverIssuesAuthChallenge(serverUrl: string, headers: Record<string, string> = {}): Promise<boolean> {
+  try {
+    const response = await fetch(serverUrl, {
+      method: 'GET',
+      headers: { ...headers, accept: 'application/json, text/event-stream' },
+      signal: AbortSignal.timeout(5000),
+    })
+    debugLog('Probed the server for an auth challenge', { status: response.status })
+    return response.status === 401
+  } catch (error) {
+    // Unreachable or too slow to say. Leave it to the 401 handler, as before.
+    debugLog('Could not probe the server for an auth challenge', error)
+    return false
+  }
+}
+
 /** Whether a usable access token is already on disk, so no sign-in is needed at all. */
 export async function hasUsableTokens(serverUrlHash: string): Promise<boolean> {
   return tokensOnDisk(serverUrlHash)
@@ -189,7 +213,15 @@ export async function coordinateAuth(
       log(`This instance is running the sign-in for this server (callback port ${actualPort})`)
       return { server, actualPort, waitForAuthCode, skipBrowserAuth: false }
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EADDRINUSE') throw error
+      const code = (error as NodeJS.ErrnoException).code
+      if (code !== 'EADDRINUSE' && code !== 'EACCES') throw error
+
+      if (code === 'EACCES') {
+        // Reserved by the OS rather than held by anyone we can talk to
+        debugLog(`Not permitted to bind port ${port}`, { serverUrlHash })
+        if (strictPort) throw error
+        continue
+      }
 
       if (await portHeldBySiblingFor(port, serverUrlHash)) {
         log(`Another instance is running the sign-in for this server on port ${port}`)
@@ -230,7 +262,9 @@ async function followUntilTokensOrPort(
   events: EventEmitter,
   authTimeoutMs: number,
 ): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
-  const deadline = Date.now() + TOKEN_HANDOFF_TIMEOUT_MS
+  // Bounded by how long a sign-in is allowed to take, not by a fixed handoff window: the person
+  // at the browser may be going through SSO, MFA or a password manager.
+  const deadline = Date.now() + Math.max(authTimeoutMs, TOKEN_HANDOFF_TIMEOUT_MS)
 
   while (Date.now() < deadline) {
     if (await tokensOnDisk(serverUrlHash)) {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -23,7 +23,7 @@ import {
 } from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
 import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
-import { createLazyAuthCoordinator, hasUsableTokens } from './lib/coordination'
+import { createLazyAuthCoordinator, hasUsableTokens, serverIssuesAuthChallenge } from './lib/coordination'
 
 /**
  * Main function to run the proxy
@@ -117,7 +117,7 @@ async function runProxy(
   // discovered it was a follower afterwards would already have registered its own client and
   // issued its own PKCE challenge - which is what produced one registration and one tab per
   // instance. Skipped when tokens are already on disk, so a warm start still binds nothing.
-  if (!(await hasUsableTokens(serverUrlHash))) {
+  if (!(await hasUsableTokens(serverUrlHash)) && (await serverIssuesAuthChallenge(serverUrl, headers))) {
     await authInitializer()
   }
 

--- a/test/concurrent-instances.test.ts
+++ b/test/concurrent-instances.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest'
 import net from 'net'
-import { startOAuthSimulator, type OAuthSimulator } from './oauth-simulator/server'
+import { startOAuthSimulator, startPublicMcpServer, type OAuthSimulator } from './oauth-simulator/server'
 import { runInstances, cleanupRun } from './oauth-simulator/instances'
 
 /**
@@ -109,6 +109,26 @@ describe('concurrent instances against one server', () => {
       expect(auth.counters.initializations).toBe(2)
     } finally {
       cleanupRun(run)
+    }
+  }, 90_000)
+
+  it('does not make instances wait for a sign-in a public server will never do', async () => {
+    // Coordinating up front only makes sense for a server that wants OAuth. A public server, or
+    // one authenticated by --header, never writes tokens - so anything waiting on them waits
+    // forever, and every instance after the first used to exit non-zero.
+    const publicServer = await startPublicMcpServer()
+
+    try {
+      const run = await runInstances({ count: 3, serverUrl: `${publicServer.url}/mcp`, settleMs: 15_000 })
+
+      try {
+        expect(run.tabs).toHaveLength(0)
+        expect(publicServer.initializations).toBe(3)
+      } finally {
+        cleanupRun(run)
+      }
+    } finally {
+      await publicServer.close()
     }
   }, 90_000)
 })

--- a/test/oauth-simulator/server.ts
+++ b/test/oauth-simulator/server.ts
@@ -214,3 +214,54 @@ export async function startOAuthSimulator(): Promise<OAuthSimulator> {
       }),
   }
 }
+
+export type PublicMcpServer = { url: string; initializations: number; close: () => Promise<void> }
+
+/**
+ * An MCP server that never asks for OAuth, as a public one or one authenticated by `--header` is.
+ *
+ * Instances must not coordinate a sign-in for a server that will never have one: no tokens are
+ * ever written, so anything waiting for them waits forever.
+ */
+export async function startPublicMcpServer(): Promise<PublicMcpServer> {
+  const app = express()
+  app.use(express.json())
+  const state = { initializations: 0 }
+
+  app.all('/mcp', (req, res) => {
+    if (req.body?.method === 'initialize') {
+      state.initializations++
+      res.json({
+        jsonrpc: '2.0',
+        id: req.body.id,
+        result: {
+          protocolVersion: req.body?.params?.protocolVersion ?? '2024-11-05',
+          capabilities: { tools: {} },
+          serverInfo: { name: 'public-mcp', version: '1.0.0' },
+        },
+      })
+      return
+    }
+    if (req.body?.id === undefined) {
+      res.status(202).end()
+      return
+    }
+    res.json({ jsonrpc: '2.0', id: req.body.id, result: {} })
+  })
+
+  const server: Server = await new Promise((resolve) => {
+    const s = app.listen(0, '127.0.0.1', () => resolve(s))
+  })
+  const port = (server.address() as AddressInfo).port
+
+  return {
+    url: `http://127.0.0.1:${port}`,
+    get initializations() {
+      return state.initializations
+    },
+    close: () =>
+      new Promise((resolve) => {
+        server.close(() => resolve())
+      }),
+  }
+}


### PR DESCRIPTION
Fixes a regression I introduced in #325. Closes #265.

## The regression

#325 settles which instance owns the OAuth flow *before* the first connection attempt, because the SDK registers a client from inside `transport.start()`. But it gated that on "no `tokens.json`" — and a public server, or one authenticated with `--header`, never writes tokens.

So every instance after the first became a follower waiting for a sign-in that was never going to happen, and exited non-zero after the handoff timeout. Reproduced against a server that needs no auth at all:

```
[46842] Another instance is running the sign-in for this server on port 3480
[46842] Fatal error: Error: Timed out waiting for another mcp-remote instance to finish
        signing in on port 3480. Retry, or close the other instance.
B exit code: 1
```

Claude Desktop starts several instances per server, so this was broadly reachable. Pre-#325 both instances connected fine.

## The fix

Coordinate only when the server actually issues a challenge — one unauthenticated `GET`, checked for a 401, before deciding to bind. If the server is unreachable or answers something else, nothing is coordinated and the 401 handler works as it did before.

## Also here

- **EACCES now walks to the next candidate port** instead of aborting (#265). Windows reserves port ranges via Hyper-V, so a derived port can be unbindable rather than taken. `findAvailablePort` — which that issue names — was deleted in #325, but the crash had simply moved to `coordinateAuth`, and with the pre-connect bind it would have aborted startup even for servers needing no auth. The reporter's suggested fix, applied.
- **A follower now waits as long as a sign-in is allowed to take** (`--auth-timeout`) rather than a fixed 30s from process start. Anyone going through SSO, MFA or a password manager was killing every non-owner instance while the owner succeeded.

## Tests

A new e2e scenario runs three instances against a server that never asks for OAuth and asserts no tab is opened and all three connect. It fails against current `main` (1 of 3 connect) and passes here.

Full suites: 177 unit, 10 e2e.
