### PR TITLE
Key the code verifier to the flow instead of the process

### DIFF
--- a/src/lib/connect-to-remote-server.test.ts
+++ b/src/lib/connect-to-remote-server.test.ts
@@ -69,6 +69,7 @@ vi.mock('@modelcontextprotocol/sdk/client/index.js', () => {
 
 // Import after mocks are registered.
 import { connectToRemoteServer } from './utils'
+import type { AuthCodeResult } from './types'
 
 describe('connectToRemoteServer', () => {
   beforeEach(() => {
@@ -81,7 +82,7 @@ describe('connectToRemoteServer', () => {
 
   it('completes auth on the transport that received the 401 challenge in proxy mode (regression: #270)', async () => {
     const authInitializer = vi.fn().mockResolvedValue({
-      waitForAuthCode: async () => 'auth-code-123',
+      waitForAuthCode: async () => ({ code: 'auth-code-123' }),
       skipBrowserAuth: false,
     })
 
@@ -107,7 +108,7 @@ describe('connectToRemoteServer', () => {
 
   it('completes auth on the main transport in with-client mode (parity with the working standalone client path)', async () => {
     const authInitializer = vi.fn().mockResolvedValue({
-      waitForAuthCode: async () => 'auth-code-456',
+      waitForAuthCode: async () => ({ code: 'auth-code-456' }),
       skipBrowserAuth: false,
     })
 
@@ -134,7 +135,7 @@ describe('connectToRemoteServer', () => {
   // What `coordinateAuth` hands a secondary instance once a sibling has finished the browser flow:
   // there is no code to wait for, so awaiting one blocks until the MCP host times the server out.
   const secondaryInstanceAuth = () => ({
-    waitForAuthCode: vi.fn(() => new Promise<string>(() => {})),
+    waitForAuthCode: vi.fn(() => new Promise<AuthCodeResult>(() => {})),
     skipBrowserAuth: true,
   })
 
@@ -169,7 +170,7 @@ describe('connectToRemoteServer', () => {
   it('does not re-exchange a spent authorization code when the retry also fails (regression: #322)', async () => {
     // A real callback server retains the code it received, so a second call yields the same one
     const authInitializer = vi.fn().mockResolvedValue({
-      waitForAuthCode: async () => 'auth-code-789',
+      waitForAuthCode: async () => ({ code: 'auth-code-789' }),
       skipBrowserAuth: false,
     })
     mockState.connectFailuresRemaining = Number.MAX_SAFE_INTEGER

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -1,6 +1,7 @@
 import { readJsonFile } from './mcp-auth-config'
 import { OAuthTokensSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { OAuthTokensWithExpiresAtSchema } from './node-oauth-client-provider'
+import { AuthCodeResult } from './types'
 import { EventEmitter } from 'events'
 import { Server } from 'http'
 import express from 'express'
@@ -11,7 +12,12 @@ const TOKEN_HANDOFF_TIMEOUT_MS = 30_000
 const TOKEN_HANDOFF_POLL_INTERVAL_MS = 200
 
 export type AuthCoordinator = {
-  initializeAuth: () => Promise<{ server: Server; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean; actualPort: number }>
+  initializeAuth: () => Promise<{
+    server: Server
+    waitForAuthCode: () => Promise<AuthCodeResult>
+    skipBrowserAuth: boolean
+    actualPort: number
+  }>
 }
 
 /**
@@ -37,7 +43,7 @@ export function createLazyAuthCoordinator(
   // process down with an unhandled EADDRINUSE (https://github.com/geelen/mcp-remote/issues/317).
   let authState: Promise<{
     server: Server
-    waitForAuthCode: () => Promise<string>
+    waitForAuthCode: () => Promise<AuthCodeResult>
     skipBrowserAuth: boolean
     actualPort: number
   }> | null = null
@@ -172,7 +178,7 @@ export async function coordinateAuth(
   events: EventEmitter,
   authTimeoutMs: number,
   strictPort = false,
-): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
+): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<AuthCodeResult>; skipBrowserAuth: boolean }> {
   debugLog('Coordinating authentication', { serverUrlHash, callbackPath, callbackPort })
 
   // Pinned by --port or by static client info: that exact port or nothing, since the redirect_uri
@@ -251,7 +257,7 @@ async function followUntilTokensOrPort(
   port: number,
   events: EventEmitter,
   authTimeoutMs: number,
-): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
+): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<AuthCodeResult>; skipBrowserAuth: boolean }> {
   // Bounded by how long a sign-in is allowed to take, not by a fixed handoff window: the person
   // at the browser may be going through SSO, MFA or a password manager.
   const deadline = Date.now() + Math.max(authTimeoutMs, TOKEN_HANDOFF_TIMEOUT_MS)

--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -173,7 +173,7 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
   // concurrent mcp-remote processes for the same server used to share a single
   // code_verifier.txt file, so a second process starting mid-flow would silently
   // overwrite the first process's verifier and break its PKCE token exchange.
-  describe('PKCE code verifier isolation across processes', () => {
+  describe('PKCE code verifier isolation across flows', () => {
     let mockReadTextFile: any
     let mockWriteTextFile: any
 
@@ -184,22 +184,46 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       mockReadTextFile.mockResolvedValue('test-verifier')
     })
 
-    it('should save the code verifier to a filename scoped to the current process ID', async () => {
+    it('should save the code verifier to a filename scoped to the authorization state', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       await provider.saveCodeVerifier('test-verifier')
 
-      expect(mockWriteTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`, 'test-verifier')
+      expect(mockWriteTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`, 'test-verifier')
       // Two processes for the same server must never target the same filename
       expect(mockWriteTextFile).not.toHaveBeenCalledWith('test-hash', 'code_verifier.txt', 'test-verifier')
     })
 
-    it('should read the code verifier back from the same process-scoped filename', async () => {
+    it('should read the code verifier back from the same flow-scoped filename', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
 
       await provider.codeVerifier()
 
-      expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`, expect.any(String))
+      expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`, expect.any(String))
+    })
+
+    it('should read the verifier of the flow a code came from, not its own', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+      // A tab opened by an instance the host has since stopped
+      provider.useAuthorizationState('11111111-2222-3333-4444-555555555555')
+
+      await provider.codeVerifier()
+
+      expect(mockReadTextFile).toHaveBeenCalledWith(
+        'test-hash',
+        'code_verifier_11111111-2222-3333-4444-555555555555.txt',
+        expect.any(String),
+      )
+    })
+
+    it('should ignore a state it could not have issued', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      // A crafted state would otherwise be interpolated straight into a config file path
+      provider.useAuthorizationState('../../../../etc/passwd')
+      await provider.codeVerifier()
+
+      expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`, expect.any(String))
     })
 
     it('should delete the process-scoped verifier file when invalidating the verifier scope', async () => {
@@ -207,7 +231,7 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
 
       await provider.invalidateCredentials('verifier')
 
-      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`)
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`)
     })
 
     it('should delete the process-scoped verifier file when invalidating all credentials', async () => {
@@ -215,7 +239,7 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
 
       await provider.invalidateCredentials('all')
 
-      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${process.pid}.txt`)
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`)
     })
   })
 

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -29,6 +29,9 @@ export const OAuthTokensWithExpiresAtSchema = OAuthTokensSchema.extend({
 })
 type OAuthTokensWithExpiresAt = z.infer<typeof OAuthTokensWithExpiresAtSchema>
 
+/** The shape of the state we issue, and the only shape accepted into a config filename. */
+const ISSUED_STATE = /^[A-Za-z0-9-]{1,64}$/
+
 /**
  * Implements the OAuthClientProvider interface for Node.js environments.
  * Handles OAuth flow and token storage for MCP clients.
@@ -51,6 +54,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   validateResourceURL?: (defaultResource: URL, discoveredResource?: string) => Promise<URL | undefined>
   private _state: string
   private _clientInfo: OAuthClientInformationFull | undefined
+  private incomingState: string | undefined
   private authorizationServerMetadata: AuthorizationServerMetadata | undefined
   private protectedResourceMetadata: ProtectedResourceMetadata | undefined
   private wwwAuthenticateScope: string | undefined
@@ -429,15 +433,37 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   /**
    * Saves the PKCE code verifier
    *
-   * The filename is scoped to the current process ID. Only the instance that owns the callback
-   * port runs a flow now (see coordination.ts), so nothing should be contending for this file -
-   * the scoping is kept as a backstop for any path that reaches here without that ownership.
-   * See https://github.com/geelen/mcp-remote/issues/235.
+   * The filename is scoped to this flow's authorization state rather than to the process, so a
+   * code can still be redeemed by an instance that took the callback port over from the one that
+   * started the flow. See https://github.com/geelen/mcp-remote/issues/235.
    * @param codeVerifier The code verifier to save
    */
   async saveCodeVerifier(codeVerifier: string): Promise<void> {
     debugLog('Saving code verifier')
-    await writeTextFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`, codeVerifier)
+    await writeTextFile(this.serverUrlHash, this.codeVerifierFile(this._state), codeVerifier)
+  }
+
+  /**
+   * Records the state a code came back with, so the flow that produced it decides which verifier
+   * redeems it
+   * @param state The state from the callback
+   */
+  useAuthorizationState(state: string): void {
+    if (!ISSUED_STATE.test(state)) {
+      log('Ignoring an authorization state this client could not have issued')
+      debugLog('Rejected authorization state', { state })
+      return
+    }
+    this.incomingState = state
+  }
+
+  /** The flow this instance is redeeming for: another instance's when a code names it. */
+  private get flowState(): string {
+    return this.incomingState ?? this._state
+  }
+
+  private codeVerifierFile(state: string): string {
+    return `code_verifier_${state}.txt`
   }
 
   /**
@@ -446,7 +472,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    */
   async codeVerifier(): Promise<string> {
     debugLog('Reading code verifier')
-    const verifier = await readTextFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`, 'No code verifier saved for session')
+    const verifier = await readTextFile(this.serverUrlHash, this.codeVerifierFile(this.flowState), 'No code verifier saved for session')
     debugLog('Code verifier found:', !!verifier)
     return verifier
   }
@@ -463,7 +489,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
         await Promise.all([
           deleteConfigFile(this.serverUrlHash, 'client_info.json'),
           deleteConfigFile(this.serverUrlHash, 'tokens.json'),
-          deleteConfigFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`),
+          deleteConfigFile(this.serverUrlHash, this.codeVerifierFile(this.flowState)),
         ])
         this._clientInfo = undefined
         debugLog('All credentials invalidated')
@@ -481,7 +507,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
         break
 
       case 'verifier':
-        await deleteConfigFile(this.serverUrlHash, `code_verifier_${process.pid}.txt`)
+        await deleteConfigFile(this.serverUrlHash, this.codeVerifierFile(this.flowState))
         debugLog('Code verifier invalidated')
         break
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -59,6 +59,12 @@ export interface OAuthCallbackServerOptions {
   serverUrlHash: string
 }
 
+/** An authorization code, with the state identifying the flow it belongs to. */
+export type AuthCodeResult = {
+  code: string
+  state?: string
+}
+
 // optional tatic OAuth client information
 export type StaticOAuthClientMetadata = OAuthClientMetadata | null | undefined
 export type StaticOAuthClientInformationFull = OAuthClientInformationFull | null | undefined

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1653,7 +1653,7 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
 
     const response = await fetch(`http://127.0.0.1:${result.actualPort}/custom/callback?code=test-code`)
     expect(response.status).toBe(200)
-    await expect(result.waitForAuthCode()).resolves.toBe('test-code')
+    await expect(result.waitForAuthCode()).resolves.toEqual({ code: 'test-code', state: undefined })
 
     // The default path must not be served when it was overridden, otherwise the redirect URI
     // we advertise and the endpoint we listen on can silently disagree

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,7 @@ import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontex
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { OAuthClientInformationFull, OAuthClientInformationFullSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
-import { OAuthCallbackServerOptions, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './types'
+import { AuthCodeResult, OAuthCallbackServerOptions, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './types'
 import { getConfigDir, getConfigFilePath, readJsonFile } from './mcp-auth-config'
 import {
   discoverProtectedResourceMetadata,
@@ -522,7 +522,7 @@ export async function discoverOAuthServerInfo(
  * Type for the auth initialization function
  */
 export type AuthInitializer = () => Promise<{
-  waitForAuthCode: () => Promise<string>
+  waitForAuthCode: () => Promise<AuthCodeResult>
   skipBrowserAuth: boolean
 }>
 
@@ -703,8 +703,13 @@ export async function connectToRemoteServer(
 
       // Wait for the authorization code from the callback
       debugLog('Waiting for auth code from callback server')
-      const code = await waitForAuthCode()
+      const { code, state } = await waitForAuthCode()
       debugLog('Received auth code from callback server')
+
+      // The code may belong to a flow another instance started, whose verifier is not this one's
+      if (state && 'useAuthorizationState' in authProvider && typeof authProvider.useAuthorizationState === 'function') {
+        authProvider.useAuthorizationState(state)
+      }
 
       // Checked before the exchange, not after: an authorization code is single-use (RFC 6749
       // 4.1.2) and the callback server hands back the same retained code on a second call, so
@@ -755,15 +760,15 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   server: Server
   actualPort: number
   authCode: string | null
-  waitForAuthCode: () => Promise<string>
-  authCompletedPromise: Promise<string>
+  waitForAuthCode: () => Promise<AuthCodeResult>
+  authCompletedPromise: Promise<AuthCodeResult>
 }> {
-  let authCode: string | null = null
+  let authCode: AuthCodeResult | null = null
   const app = express()
 
   // Create a promise to track when auth is completed
-  let authCompletedResolve: (code: string) => void
-  const authCompletedPromise = new Promise<string>((resolve) => {
+  let authCompletedResolve: (result: AuthCodeResult) => void
+  const authCompletedPromise = new Promise<AuthCodeResult>((resolve) => {
     authCompletedResolve = resolve
   })
 
@@ -816,14 +821,15 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   // OAuth callback endpoint
   app.get(options.path, (req, res) => {
     const code = req.query.code as string | undefined
+    const state = req.query.state as string | undefined
     if (!code) {
       res.status(400).send('Error: No authorization code received')
       return
     }
 
-    authCode = code
+    authCode = { code, state }
     log('Auth code received, resolving promise')
-    authCompletedResolve(code)
+    authCompletedResolve(authCode)
 
     res.send(`
       Authorization successful!
@@ -837,7 +843,7 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
     `)
 
     // Notify main flow that auth code is available
-    options.events.emit('auth-code-received', code)
+    options.events.emit('auth-code-received', code, state)
   })
 
   // Bind the server. There is deliberately no random-port fallback: the deterministic port is
@@ -864,15 +870,15 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
     })
   })
 
-  const waitForAuthCode = (): Promise<string> => {
+  const waitForAuthCode = (): Promise<AuthCodeResult> => {
     return new Promise((resolve) => {
       if (authCode) {
         resolve(authCode)
         return
       }
 
-      options.events.once('auth-code-received', (code) => {
-        resolve(code)
+      options.events.once('auth-code-received', (code: string, state?: string) => {
+        resolve({ code, state })
       })
     })
   }

--- a/test/concurrent-instances.test.ts
+++ b/test/concurrent-instances.test.ts
@@ -98,6 +98,27 @@ describe('concurrent instances against one server', () => {
     }
   }, 120_000)
 
+  it('completes the sign-in from the tab the killed instance opened', async () => {
+    // The tab is followed only after the instance that opened it is gone, which is the ordering a
+    // user produces: the host stops the instance seconds in, they approve a moment later.
+    const run = await runInstances({
+      count: 3,
+      serverUrl: `${auth.url}/mcp`,
+      settleMs: 25_000,
+      killTabOwnerAfterMs: 1500,
+      approveFirstTabAfterKillMs: 2000,
+    })
+
+    try {
+      expect(run.killedPid).toBeDefined()
+      expect(auth.counters.tokenFailures).toEqual([])
+      expect(auth.counters.tokensIssued).toBe(1)
+      expect(auth.counters.initializations).toBeGreaterThanOrEqual(1)
+    } finally {
+      cleanupRun(run)
+    }
+  }, 120_000)
+
   it('steps past a port held by an unrelated process', async () => {
     // The derived port is not reserved for us. Something else holding it must not make every
     // instance wait for a sign-in that is never coming.

--- a/test/oauth-simulator/browser-stub.mjs
+++ b/test/oauth-simulator/browser-stub.mjs
@@ -10,7 +10,8 @@ import { appendFileSync } from 'fs'
  */
 export default async function open(url) {
   appendFileSync(process.env.MCP_TEST_TAB_LOG, `${Date.now()} ${process.pid} ${url}\n`)
-  void followLikeABrowser(url)
+  // A scenario that approves the tab itself leaves it alone here
+  if (!process.env.MCP_TEST_TABS_APPROVED_EXTERNALLY) void followLikeABrowser(url)
   // `open` resolves with the helper's ChildProcess; callers may attach listeners or unref it
   return { on() {}, once() {}, unref() {}, stderr: null, kill() {} }
 }

--- a/test/oauth-simulator/instances.ts
+++ b/test/oauth-simulator/instances.ts
@@ -31,6 +31,11 @@ export type RunOptions = {
   settleMs?: number
   /** Kills the instance that opened the first tab, this long after it opens. */
   killTabOwnerAfterMs?: number
+  /**
+   * Approves the first tab this long after the instance that opened it was killed, from the
+   * harness rather than from inside an instance - a browser outlives the process that opened it.
+   */
+  approveFirstTabAfterKillMs?: number
   /** Reuses an existing config dir, standing in for a restart after a successful sign-in. */
   configDir?: string
   /** Holds the port these instances would derive, standing in for an unrelated process. */
@@ -65,6 +70,7 @@ export async function runInstances(options: RunOptions): Promise<InstanceRun> {
         ...process.env,
         MCP_REMOTE_CONFIG_DIR: configDir,
         MCP_TEST_TAB_LOG: tabLog,
+        ...(options.approveFirstTabAfterKillMs === undefined ? {} : { MCP_TEST_TABS_APPROVED_EXTERNALLY: '1' }),
         NODE_OPTIONS: `--import ${pathToImport(path.join(here, 'browser-hook.mjs'))}`,
       },
     })
@@ -94,6 +100,13 @@ export async function runInstances(options: RunOptions): Promise<InstanceRun> {
     }
   }
 
+  if (options.approveFirstTabAfterKillMs !== undefined) {
+    await new Promise((resolve) => setTimeout(resolve, options.approveFirstTabAfterKillMs))
+    const [firstTab] = readTabUrls(tabLog)
+    // Following the redirect chain is what a browser does: authorize, then the callback
+    if (firstTab) await fetch(firstTab).catch(() => {})
+  }
+
   await new Promise((resolve) => setTimeout(resolve, settleMs))
   for (const child of children) child.kill('SIGKILL')
   if (squatter) await squatter.release()
@@ -114,6 +127,14 @@ export async function runInstances(options: RunOptions): Promise<InstanceRun> {
     killedPid,
     configDir,
   }
+}
+
+function readTabUrls(tabLog: string): string[] {
+  if (!existsSync(tabLog)) return []
+  return readFileSync(tabLog, 'utf-8')
+    .split('\n')
+    .filter(Boolean)
+    .map((line) => line.split(' ').slice(2).join(' '))
 }
 
 function readTabPids(tabLog: string): number[] {


### PR DESCRIPTION
Follow-up to #325. The port mutex made the group behave for concurrent starts; this covers what happens when the instance that opened the tab is stopped before the user approves it, which is the ordering an MCP host produces routinely.

## The gap

`followUntilTokensOrPort` already says what should happen:

> The port came free, so the instance that had it is gone. Whatever tab it opened points here, so its sign-in can still complete against this process.

It cannot, because the verifier is `code_verifier_${process.pid}.txt`. The survivor rebinds the port, inherits the redirect URI and the shared registration, receives the code from the tab that is still open, and redeems it with a verifier from a different flow.

The first commit adds the scenario to the existing harness. The browser is driven from the harness rather than from inside an instance, because a tab outlives the process that opened it - following it in-process meant `SIGKILL` also cancelled the pending approval, which is why the existing kill scenario never reached the exchange.

Against `main`:

```
tokensIssued:  0
tokenFailures: [pkce_mismatch, pkce_mismatch]
initializations: 0

[survivor] The instance running the sign-in exited; taking it over on port 19451
[survivor] Authorization error: InvalidGrantError: pkce_mismatch
[survivor] Fatal error
```

`takes the flow over when the instance running it is killed mid-sign-in` passes here because it allows two tabs and does not assert that a token was issued.

## The change

The second commit keys the verifier by the authorization `state` and carries that state back from the callback, so a code is redeemed with the verifier of the flow that produced it. A state that this client could not have issued is ignored rather than interpolated into a filename.

No new files, no lockfile, no marker, no TTL: which instance owns the flow is still decided by the port.

## Result

| | tokens issued | token failures | instances working |
|---|---|---|---|
| `main` | 0 | `pkce_mismatch` x2 | 0 |
| this branch | 1 | none | 2 of 3 |

177 unit tests, `tsc` and `prettier` pass. The concurrency harness passes all seven scenarios.
