### PR TITLE
Treat an unrefreshable expired token as needing a sign-in

### DIFF
--- a/src/lib/coordination.test.ts
+++ b/src/lib/coordination.test.ts
@@ -3,46 +3,10 @@ import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
 import { writeJsonFile } from './mcp-auth-config'
-import { waitForTokensFromPrimary, createLazyAuthCoordinator } from './coordination'
+import { createLazyAuthCoordinator, hasUsableTokens } from './coordination'
 import { EventEmitter } from 'events'
 import net from 'net'
 import http from 'http'
-
-describe('Feature: Token handoff between concurrent instances', () => {
-  const hash = 'handoff-test'
-  let configDir: string
-
-  beforeEach(async () => {
-    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-remote-handoff-'))
-    process.env.MCP_REMOTE_CONFIG_DIR = configDir
-    // coordinateAuth logs to stderr; keep the test output readable
-    vi.spyOn(console, 'error').mockImplementation(() => {})
-  })
-
-  afterEach(async () => {
-    delete process.env.MCP_REMOTE_CONFIG_DIR
-    await fs.rm(configDir, { recursive: true, force: true })
-  })
-
-  it('Scenario: Resolves once the primary instance persists its tokens', async () => {
-    // Given tokens that are not on disk yet - the primary's callback fired, but the code has
-    // not been exchanged. This is the window a fixed sleep used to gamble on.
-    const waiting = waitForTokensFromPrimary(hash, 5000)
-
-    // When the primary finishes the exchange and writes them
-    await new Promise((resolve) => setTimeout(resolve, 300))
-    await writeJsonFile(hash, 'tokens.json', { access_token: 'from-primary', token_type: 'Bearer' })
-
-    // Then the secondary stops waiting
-    await expect(waiting).resolves.toBe(true)
-  })
-
-  it('Scenario: Gives up when the primary never writes them', async () => {
-    // Given a primary that signalled completion but never persisted anything
-    // Then the secondary reports failure instead of blocking forever
-    await expect(waitForTokensFromPrimary(hash, 500)).resolves.toBe(false)
-  })
-})
 
 describe('Feature: Two 401s arriving in the same tick', () => {
   let configDir: string
@@ -93,4 +57,46 @@ describe('Feature: Two 401s arriving in the same tick', () => {
     expect(retried.actualPort).toBe(blockedPort)
     retried.server.close()
   }, 15_000)
+})
+
+describe('Feature: Deciding whether a browser sign-in is needed', () => {
+  let configDir: string
+
+  beforeEach(async () => {
+    configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-remote-usable-'))
+    process.env.MCP_REMOTE_CONFIG_DIR = configDir
+  })
+
+  afterEach(async () => {
+    delete process.env.MCP_REMOTE_CONFIG_DIR
+    await fs.rm(configDir, { recursive: true, force: true })
+  })
+
+  const store = (tokens: Record<string, unknown>) => writeJsonFile('usable-test', 'tokens.json', tokens)
+
+  it('Scenario: No tokens at all means a sign-in is needed', async () => {
+    await expect(hasUsableTokens('usable-test')).resolves.toBe(false)
+  })
+
+  it('Scenario: A live token needs nothing', async () => {
+    await store({ access_token: 'a', token_type: 'Bearer', expires_at: Date.now() + 3_600_000 })
+    await expect(hasUsableTokens('usable-test')).resolves.toBe(true)
+  })
+
+  it('Scenario: An expired token that can be refreshed needs no browser', async () => {
+    await store({ access_token: 'a', token_type: 'Bearer', expires_at: Date.now() - 1000, refresh_token: 'r' })
+    await expect(hasUsableTokens('usable-test')).resolves.toBe(true)
+  })
+
+  it('Scenario: An expired token with nothing to refresh from needs a sign-in', async () => {
+    // Treating this as usable is what let every instance skip coordination on re-authentication
+    // and open a tab of its own
+    await store({ access_token: 'a', token_type: 'Bearer', expires_at: Date.now() - 1000 })
+    await expect(hasUsableTokens('usable-test')).resolves.toBe(false)
+  })
+
+  it('Scenario: A token expiring within the refresh margin counts as expired', async () => {
+    await store({ access_token: 'a', token_type: 'Bearer', expires_at: Date.now() + 5_000 })
+    await expect(hasUsableTokens('usable-test')).resolves.toBe(false)
+  })
 })

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -1,5 +1,6 @@
 import { readJsonFile } from './mcp-auth-config'
 import { OAuthTokensSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
+import { OAuthTokensWithExpiresAtSchema } from './node-oauth-client-provider'
 import { EventEmitter } from 'events'
 import { Server } from 'http'
 import express from 'express'
@@ -66,36 +67,6 @@ export function createLazyAuthCoordinator(
 }
 
 /**
- * Waits for the primary instance to persist the tokens it obtained.
- *
- * The owner's callback server receives a code strictly before it has exchanged it for
- * authorization code, which is strictly earlier than the code being exchanged and the result
- * written to disk. Reconnecting in that window reads no tokens and 401s again, so poll for the
- * file rather than guessing at a fixed delay.
- *
- * @param serverUrlHash The hash of the server URL
- * @returns True if tokens showed up before the timeout
- */
-export async function waitForTokensFromPrimary(serverUrlHash: string, timeoutMs = TOKEN_HANDOFF_TIMEOUT_MS): Promise<boolean> {
-  const deadline = Date.now() + timeoutMs
-
-  while (true) {
-    const tokens = await readJsonFile(serverUrlHash, 'tokens.json', OAuthTokensSchema)
-    if (tokens) {
-      debugLog('Tokens from the primary instance are on disk')
-      return true
-    }
-
-    if (Date.now() >= deadline) {
-      log(`Timed out after ${Math.round(timeoutMs / 1000)}s waiting for the other instance to write its tokens`)
-      return false
-    }
-
-    await new Promise((resolve) => setTimeout(resolve, TOKEN_HANDOFF_POLL_INTERVAL_MS))
-  }
-}
-
-/**
  * Coordinates authentication between multiple instances of the client/proxy
  * @param serverUrlHash The hash of the server URL
  * @param callbackPath The path to serve the callback endpoint on
@@ -154,9 +125,25 @@ export async function serverIssuesAuthChallenge(serverUrl: string, headers: Reco
   }
 }
 
-/** Whether a usable access token is already on disk, so no sign-in is needed at all. */
+/**
+ * Whether the tokens on disk make a browser sign-in unnecessary.
+ *
+ * Not simply "a token exists": an expired one with a refresh token is renewed without the
+ * browser, while an expired one without is exactly the case that needs a flow - and treating it
+ * as usable is what let every instance skip coordination on re-authentication and open its own
+ * tab, which is the storm of login windows people report after a token lapses.
+ */
 export async function hasUsableTokens(serverUrlHash: string): Promise<boolean> {
-  return tokensOnDisk(serverUrlHash)
+  const tokens = await readJsonFile<{ expires_at?: number; refresh_token?: string }>(
+    serverUrlHash,
+    'tokens.json',
+    OAuthTokensWithExpiresAtSchema,
+  )
+  if (!tokens) return false
+  if (tokens.expires_at && Date.now() >= tokens.expires_at - TOKEN_EXPIRY_MARGIN_MS) {
+    return !!tokens.refresh_token
+  }
+  return true
 }
 
 /** Tokens another instance has already obtained, if they are on disk and usable. */
@@ -164,6 +151,9 @@ async function tokensOnDisk(serverUrlHash: string): Promise<boolean> {
   const tokens = await readJsonFile(serverUrlHash, 'tokens.json', OAuthTokensSchema)
   return !!tokens
 }
+
+/** Treat a token about to expire as expired, matching the provider's own refresh margin. */
+const TOKEN_EXPIRY_MARGIN_MS = 60_000
 
 /**
  * Takes ownership of a server's OAuth flow, or waits for whoever has it.

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -24,7 +24,7 @@ import { getAuthorizationServerUrl, type ProtectedResourceMetadata } from './pro
  * otherwise drop `expires_at` on read, so we parse and serialize tokens with
  * this extended schema instead.
  */
-const OAuthTokensWithExpiresAtSchema = OAuthTokensSchema.extend({
+export const OAuthTokensWithExpiresAtSchema = OAuthTokensSchema.extend({
   expires_at: z.coerce.number().optional(),
 })
 type OAuthTokensWithExpiresAt = z.infer<typeof OAuthTokensWithExpiresAtSchema>
@@ -429,14 +429,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   /**
    * Saves the PKCE code verifier
    *
-   * The filename is scoped to the current process ID. Multiple mcp-remote
-   * processes can be started concurrently for the same server (e.g. an MCP
-   * host reconnecting or launching duplicate instances) - since coordination
-   * between those processes is currently disabled on Windows (see
-   * coordination.ts), each process must keep its own verifier so a second
-   * process can't overwrite the first one's file mid-flow and break the
-   * PKCE exchange for whichever process the browser callback actually
-   * reaches. See https://github.com/geelen/mcp-remote/issues/235.
+   * The filename is scoped to the current process ID. Only the instance that owns the callback
+   * port runs a flow now (see coordination.ts), so nothing should be contending for this file -
+   * the scoping is kept as a backstop for any path that reaches here without that ownership.
+   * See https://github.com/geelen/mcp-remote/issues/235.
    * @param codeVerifier The code verifier to save
    */
   async saveCodeVerifier(codeVerifier: string): Promise<void> {


### PR DESCRIPTION
Follow-up to #325/#328, closing the last gap the post-merge triage found.

## An expired token counted as usable

`hasUsableTokens` was just "a parseable `tokens.json` exists" — it returned true for a token that expired years ago. Since it gates whether ownership is settled before connecting, every instance skipped coordination on re-authentication, and each one opened its own tab from inside `connect()`. That is the storm of login windows people report after a token lapses (#149, #179, #91, #68); #325 never reached that path.

It now asks the narrower question the caller actually means — *is a browser sign-in needed?* An expired token with a refresh token is renewed without the browser, so it stays usable; an expired one with nothing to refresh from does not. The 60s margin matches the provider's own refresh margin, so the two agree on when a token is spent.

Two of the five new tests fail against `main`.

## Also

- Removed `waitForTokensFromPrimary`, which had no production callers left after #325 — the follower loop polls tokens itself. Its tests went with it; that behaviour is now covered end to end by the concurrent-instances suite.
- Corrected the comment on `saveCodeVerifier`, which still told readers coordination was disabled on Windows and justified the per-process verifier filename on that basis. Both stopped being true in #325. The scoping stays as a backstop; only the reasoning changed.

Full suites: 180 unit, 10 e2e.
