### PR TITLE
Stop a follower accepting a token that cannot be used

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -106,9 +106,10 @@ async function runClient(
     // Store server in outer scope for cleanup
     server = authState.server
 
-    // The owner may have settled on a later candidate port because strangers held earlier ones.
-    // Every instance for this server converges on the same one, so the cached registration still
-    // matches and there is nothing to invalidate.
+    // A stranger on an earlier candidate can push us onto a later port than the one the startup
+    // check compared the cached registration against, so a stale registration can still name the
+    // wrong redirect_uri here. Invalidating unconditionally is not the answer - this runs again on
+    // the post-auth reconnect, and deleting the registration then breaks the code exchange.
     if (authState.actualPort !== callbackPort) {
       log(`Using callback port ${authState.actualPort}`)
       authProvider.setCallbackPort(authState.actualPort)

--- a/src/lib/coordinate-auth.test.ts
+++ b/src/lib/coordinate-auth.test.ts
@@ -1,0 +1,161 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { EventEmitter } from 'events'
+import express from 'express'
+import net from 'net'
+import http from 'http'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { coordinateAuth, serverIssuesAuthChallenge } from './coordination'
+import { writeJsonFile } from './mcp-auth-config'
+import { MCP_REMOTE_ID_PATH } from './utils'
+
+/**
+ * Deciding who runs the sign-in.
+ *
+ * This is the substance of the port-ownership design and it shipped untested, which is how a
+ * follower came to accept the very token the pre-connect gate had just rejected.
+ */
+const HASH = 'coordinate-test'
+let configDir: string
+const opened: Array<{ close: () => Promise<void> }> = []
+
+/** Something that is not us, holding a port. */
+async function stranger(port: number): Promise<void> {
+  const server = http.createServer((_req, res) => res.writeHead(404).end())
+  await new Promise<void>((resolve) => server.listen(port, '127.0.0.1', resolve))
+  opened.push({ close: () => new Promise((r) => (server.closeAllConnections(), server.close(() => r()))) })
+}
+
+/** Something claiming to be one of us for this server, holding a port. */
+async function sibling(port: number, serverUrlHash = HASH): Promise<void> {
+  const app = express()
+  app.get(MCP_REMOTE_ID_PATH, (_req, res) => {
+    res.json({ mcpRemote: true, serverUrlHash })
+  })
+  const server = await new Promise<http.Server>((resolve) => {
+    const s = app.listen(port, '127.0.0.1', () => resolve(s))
+  })
+  opened.push({ close: () => new Promise((r) => (server.closeAllConnections(), server.close(() => r()))) })
+}
+
+async function freePort(): Promise<number> {
+  const probe = net.createServer()
+  const port = await new Promise<number>((resolve) =>
+    probe.listen(0, '127.0.0.1', () => resolve((probe.address() as net.AddressInfo).port)),
+  )
+  await new Promise<void>((resolve) => probe.close(() => resolve()))
+  return port
+}
+
+const coordinate = (port: number, patienceMs = 500) =>
+  coordinateAuth(HASH, '/oauth/callback', port, new EventEmitter(), 1000, false, patienceMs)
+
+beforeEach(async () => {
+  configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-remote-coord-'))
+  process.env.MCP_REMOTE_CONFIG_DIR = configDir
+  vi.spyOn(console, 'error').mockImplementation(() => {})
+})
+
+afterEach(async () => {
+  for (const o of opened.splice(0)) await o.close()
+  delete process.env.MCP_REMOTE_CONFIG_DIR
+  await fs.rm(configDir, { recursive: true, force: true })
+  vi.restoreAllMocks()
+})
+
+describe('Feature: Deciding who runs the sign-in', () => {
+  it('Scenario: A free port makes this instance the owner', async () => {
+    const port = await freePort()
+
+    const result = await coordinate(port)
+
+    expect(result.skipBrowserAuth).toBe(false)
+    expect(result.actualPort).toBe(port)
+    result.server.close()
+  })
+
+  it('Scenario: A sibling on the port makes this instance a follower', async () => {
+    const port = await freePort()
+    await sibling(port)
+    await writeJsonFile(HASH, 'tokens.json', { access_token: 'a', token_type: 'Bearer', expires_at: Date.now() + 3_600_000 })
+
+    const result = await coordinate(port)
+
+    expect(result.skipBrowserAuth).toBe(true)
+    expect(result.actualPort).toBe(port)
+    result.server.close()
+  })
+
+  it('Scenario: A stranger on the port is stepped over, not waited for', async () => {
+    const port = await freePort()
+    await stranger(port)
+
+    const result = await coordinate(port)
+
+    // Someone else's process is not a sign-in to wait for
+    expect(result.skipBrowserAuth).toBe(false)
+    expect(result.actualPort).toBeGreaterThan(port)
+    result.server.close()
+  })
+
+  it('Scenario: A sibling holding a token nobody can use is not mistaken for a finished sign-in', async () => {
+    // The pre-connect gate rejects an expired token with nothing to refresh from. A follower that
+    // accepted the same file would reconnect with it, get a 401, and open a tab of its own.
+    const port = await freePort()
+    await sibling(port)
+    await writeJsonFile(HASH, 'tokens.json', { access_token: 'stale', token_type: 'Bearer', expires_at: Date.now() - 60_000 })
+
+    const result = await coordinate(port, 400)
+
+    // It waited instead, then gave up - and gave up without claiming a sign-in had happened
+    expect(result.actualPort).toBe(port)
+    await expect(result.waitForAuthCode()).rejects.toThrow(/does not own the sign-in/)
+    result.server.close()
+  })
+
+  it('Scenario: Giving up on another instance does not kill this one', async () => {
+    // Every way "is a sibling signing in?" can be guessed wrong used to end in exit(1)
+    const port = await freePort()
+    await sibling(port)
+
+    const result = await coordinate(port, 400)
+
+    expect(result).toBeDefined()
+    expect(result.actualPort).toBe(port)
+    result.server.close()
+  })
+
+  it('Scenario: A sibling for a different server is a stranger', async () => {
+    const port = await freePort()
+    await sibling(port, 'some-other-server')
+
+    const result = await coordinate(port)
+
+    expect(result.skipBrowserAuth).toBe(false)
+    expect(result.actualPort).toBeGreaterThan(port)
+    result.server.close()
+  })
+})
+
+describe('Feature: Asking whether the server wants a sign-in', () => {
+  it('Scenario: A challenge means coordinate', async () => {
+    const server = http.createServer((_req, res) => res.writeHead(401).end())
+    const port = await new Promise<number>((r) => server.listen(0, '127.0.0.1', () => r((server.address() as net.AddressInfo).port)))
+    opened.push({ close: () => new Promise((r) => (server.closeAllConnections(), server.close(() => r()))) })
+
+    await expect(serverIssuesAuthChallenge(`http://127.0.0.1:${port}/mcp`)).resolves.toBe(true)
+  })
+
+  it('Scenario: A server that serves us needs no coordination', async () => {
+    const server = http.createServer((_req, res) => res.writeHead(200).end('{}'))
+    const port = await new Promise<number>((r) => server.listen(0, '127.0.0.1', () => r((server.address() as net.AddressInfo).port)))
+    opened.push({ close: () => new Promise((r) => (server.closeAllConnections(), server.close(() => r()))) })
+
+    await expect(serverIssuesAuthChallenge(`http://127.0.0.1:${port}/mcp`)).resolves.toBe(false)
+  })
+
+  it('Scenario: A server we cannot reach is left to the 401 handler', async () => {
+    await expect(serverIssuesAuthChallenge('http://127.0.0.1:9/mcp')).resolves.toBe(false)
+  })
+})

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -185,7 +185,7 @@ export async function coordinateAuth(
 ): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
   debugLog('Coordinating authentication', { serverUrlHash, callbackPath, callbackPort })
 
-  // Pinned by --port or by static client info: that exact port or nothing, since the redirect_uri
+  // Pinned by an explicit port argument or by static client info: that exact port or nothing, since the redirect_uri
   // it implies is not ours to move.
   const candidates = strictPort ? [callbackPort] : Array.from({ length: PORT_CANDIDATES }, (_, i) => callbackPort + i)
 
@@ -236,7 +236,7 @@ export async function coordinateAuth(
 
   throw new Error(
     `Could not find a free callback port for this server (tried ${candidates[0]}-${candidates[candidates.length - 1]}). ` +
-      `Close whatever is holding those ports, or pass --port to choose one.`,
+      `Close whatever is holding those ports, or pass a port as the second argument to choose one.`,
   )
 }
 

--- a/src/lib/coordination.ts
+++ b/src/lib/coordination.ts
@@ -2,12 +2,16 @@ import { readJsonFile } from './mcp-auth-config'
 import { OAuthTokensSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { OAuthTokensWithExpiresAtSchema } from './node-oauth-client-provider'
 import { EventEmitter } from 'events'
+import { Agent } from 'undici'
 import { Server } from 'http'
 import express from 'express'
 import { log, debugLog, setupOAuthCallbackServerWithLongPoll, MCP_REMOTE_ID_PATH } from './utils'
 
 /** How long a secondary instance waits for the primary to persist the tokens it just obtained. */
 const TOKEN_HANDOFF_TIMEOUT_MS = 30_000
+
+/** How long to wait on another instance's sign-in before going it alone. Sign-ins involve a human. */
+const FOLLOWER_PATIENCE_MS = 3 * 60_000
 const TOKEN_HANDOFF_POLL_INTERVAL_MS = 200
 
 export type AuthCoordinator = {
@@ -87,11 +91,21 @@ const FOLLOWER_POLL_INTERVAL_MS = 250
  * A refused bind says the port is taken, not by what. Without this an unrelated process squatting
  * on the port would make every instance wait for a sign-in that is never coming.
  */
+/**
+ * Talks to loopback directly, whatever global dispatcher is installed.
+ *
+ * `--enable-proxy` sets a global EnvHttpProxyAgent, which does not exempt loopback - so without
+ * this the identity probe is sent to the corporate proxy, times out, and every sibling is
+ * mistaken for a stranger.
+ */
+const loopbackDispatcher = new Agent()
+
 async function portHeldBySiblingFor(port: number, serverUrlHash: string): Promise<boolean> {
   try {
     const response = await fetch(`http://127.0.0.1:${port}${MCP_REMOTE_ID_PATH}`, {
       signal: AbortSignal.timeout(1000),
-    })
+      dispatcher: loopbackDispatcher,
+    } as RequestInit)
     if (!response.ok) return false
     const body = (await response.json()) as { mcpRemote?: boolean; serverUrlHash?: string }
     return body?.mcpRemote === true && body.serverUrlHash === serverUrlHash
@@ -147,11 +161,6 @@ export async function hasUsableTokens(serverUrlHash: string): Promise<boolean> {
 }
 
 /** Tokens another instance has already obtained, if they are on disk and usable. */
-async function tokensOnDisk(serverUrlHash: string): Promise<boolean> {
-  const tokens = await readJsonFile(serverUrlHash, 'tokens.json', OAuthTokensSchema)
-  return !!tokens
-}
-
 /** Treat a token about to expire as expired, matching the provider's own refresh margin. */
 const TOKEN_EXPIRY_MARGIN_MS = 60_000
 
@@ -172,6 +181,7 @@ export async function coordinateAuth(
   events: EventEmitter,
   authTimeoutMs: number,
   strictPort = false,
+  followerPatienceMs = FOLLOWER_PATIENCE_MS,
 ): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
   debugLog('Coordinating authentication', { serverUrlHash, callbackPath, callbackPort })
 
@@ -197,7 +207,7 @@ export async function coordinateAuth(
       if (established !== undefined) {
         debugLog('Yielding to a sibling established on an earlier candidate', { ours: actualPort, theirs: established })
         await new Promise<void>((resolve) => server.close(() => resolve()))
-        return followUntilTokensOrPort(serverUrlHash, callbackPath, established, events, authTimeoutMs)
+        return followUntilTokensOrPort(serverUrlHash, callbackPath, established, events, authTimeoutMs, followerPatienceMs)
       }
 
       log(`This instance is running the sign-in for this server (callback port ${actualPort})`)
@@ -215,7 +225,7 @@ export async function coordinateAuth(
 
       if (await portHeldBySiblingFor(port, serverUrlHash)) {
         log(`Another instance is running the sign-in for this server on port ${port}`)
-        return followUntilTokensOrPort(serverUrlHash, callbackPath, port, events, authTimeoutMs)
+        return followUntilTokensOrPort(serverUrlHash, callbackPath, port, events, authTimeoutMs, followerPatienceMs)
       }
 
       // Somebody else's process. Ours is not there to be waited for, so keep looking.
@@ -230,7 +240,14 @@ export async function coordinateAuth(
   )
 }
 
-/** The earliest candidate before `port` that a sibling has taken, if any. */
+/**
+ * The earliest candidate before `port` that a sibling has taken, if any.
+ *
+ * Deliberately one-directional. Binding only arbitrates between instances contending for the same
+ * port, so instances pushed past a squatted one can each think they won; yielding to the lowest
+ * bound candidate is a rule they can all evaluate identically. Yielding in both directions has no
+ * tie-break - two instances would each stand down for the other.
+ */
 async function firstSiblingBefore(candidates: number[], port: number, serverUrlHash: string): Promise<number | undefined> {
   for (const candidate of candidates) {
     if (candidate === port) return undefined
@@ -251,24 +268,18 @@ async function followUntilTokensOrPort(
   port: number,
   events: EventEmitter,
   authTimeoutMs: number,
+  followerPatienceMs: number,
 ): Promise<{ server: Server; actualPort: number; waitForAuthCode: () => Promise<string>; skipBrowserAuth: boolean }> {
-  // Bounded by how long a sign-in is allowed to take, not by a fixed handoff window: the person
-  // at the browser may be going through SSO, MFA or a password manager.
-  const deadline = Date.now() + Math.max(authTimeoutMs, TOKEN_HANDOFF_TIMEOUT_MS)
+  // The person at the browser may be going through SSO, MFA or a password manager, so this is
+  // deliberately longer than the handoff window - and running out is no longer fatal.
+  const deadline = Date.now() + Math.max(authTimeoutMs, followerPatienceMs)
 
   while (Date.now() < deadline) {
-    if (await tokensOnDisk(serverUrlHash)) {
+    if (await hasUsableTokens(serverUrlHash)) {
       log('The sign-in was completed by another instance; using the tokens it wrote')
       // This instance never serves callbacks, so it reports the port it would have used rather
       // than a throwaway one - a port that looks changed makes callers re-register the client.
-      const idleServer = express().listen(0, '127.0.0.1')
-      return {
-        server: idleServer,
-        actualPort: port,
-        waitForAuthCode: () =>
-          Promise.reject(new Error('waitForAuthCode is not available in a follower; reconnect using the tokens on disk instead')),
-        skipBrowserAuth: true,
-      }
+      return unownedFlow(port)
     }
 
     try {
@@ -290,7 +301,31 @@ async function followUntilTokensOrPort(
     await new Promise((resolve) => setTimeout(resolve, FOLLOWER_POLL_INTERVAL_MS))
   }
 
-  throw new Error(
-    `Timed out waiting for another mcp-remote instance to finish signing in on port ${port}. ` + `Retry, or close the other instance.`,
-  )
+  // Whatever we were waiting for is not coming. Connecting unaided may still work - the server
+  // may not need OAuth at all, or may challenge us and let the 401 handler run - and it is always
+  // better than exiting, which is what a wrong guess used to cost.
+  log(`Gave up waiting for another instance on port ${port}; continuing without owning the sign-in`)
+  return unownedFlow(port)
+}
+
+/**
+ * A result for an instance that owns no callback server and will not run a browser flow.
+ *
+ * `waitForAuthCode` rejects rather than hanging, so a caller that reaches for a code it was never
+ * going to receive fails immediately and visibly instead of waiting out the host's patience.
+ */
+function unownedFlow(port: number): {
+  server: Server
+  actualPort: number
+  waitForAuthCode: () => Promise<string>
+  skipBrowserAuth: boolean
+} {
+  return {
+    server: express()
+      .listen(0, '127.0.0.1')
+      .on('error', () => {}),
+    actualPort: port,
+    waitForAuthCode: () => Promise.reject(new Error('This instance does not own the sign-in; it cannot receive an authorization code')),
+    skipBrowserAuth: true,
+  }
 }

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1627,6 +1627,25 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
     }
   })
 
+  it('reports a denied authorization instead of waiting for a code that is not coming', async () => {
+    // ?error= is how "the user clicked Deny", an org policy block or invalid_scope arrives. Waiting
+    // for a code holds the callback port for the life of the process and tells the user nothing.
+    const result = await setupOAuthCallbackServerWithLongPoll({
+      port: 0,
+      path: '/oauth/callback',
+      events,
+      serverUrlHash: 'test-hash',
+    })
+    server = result.server
+    const waiting = result.waitForAuthCode()
+
+    const response = await fetch(`http://127.0.0.1:${result.actualPort}/oauth/callback?error=access_denied&error_description=User%20denied`)
+
+    expect(response.status).toBe(400)
+    await expect(response.text()).resolves.toContain('User denied')
+    await expect(waiting).rejects.toThrow(/access_denied/)
+  })
+
   it('answers an identity probe, so a losing instance can tell a sibling from a stranger', async () => {
     const result = await setupOAuthCallbackServerWithLongPoll({
       port: 0,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1637,13 +1637,18 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
       serverUrlHash: 'test-hash',
     })
     server = result.server
-    const waiting = result.waitForAuthCode()
+    // A handler is attached synchronously: the callback arrives during the await below, and a
+    // rejection with nothing attached yet is reported as unhandled even though it is asserted on
+    const settled = result.waitForAuthCode().then(
+      () => new Error('expected no authorization code'),
+      (error: Error) => error,
+    )
 
     const response = await fetch(`http://127.0.0.1:${result.actualPort}/oauth/callback?error=access_denied&error_description=User%20denied`)
 
     expect(response.status).toBe(400)
     await expect(response.text()).resolves.toContain('User denied')
-    await expect(waiting).rejects.toThrow(/access_denied/)
+    expect((await settled).message).toMatch(/access_denied/)
   })
 
   it('answers an identity probe, so a losing instance can tell a sibling from a stranger', async () => {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1023,7 +1023,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     const value = args[callbackPathIndex + 1]
     if (!value.startsWith('/')) {
       log(`Warning: Ignoring invalid callback path: ${value}. It must start with '/'.`)
-    } else if (value === LONG_POLL_PATH) {
+    } else if (value === LONG_POLL_PATH || value === MCP_REMOTE_ID_PATH) {
       log(`Warning: Ignoring reserved callback path: ${value}. It is used to coordinate concurrent instances.`)
     } else {
       callbackPath = value

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -816,6 +816,14 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   // OAuth callback endpoint
   app.get(options.path, (req, res) => {
     const code = req.query.code as string | undefined
+    const authorizationError = req.query.error as string | undefined
+    if (authorizationError) {
+      const description = (req.query.error_description as string | undefined) ?? authorizationError
+      log(`Authorization failed: ${authorizationError} - ${description}`)
+      res.status(400).send(`Authorization failed: ${description}\n\nYou may close this window and return to the CLI.`)
+      options.events.emit('auth-code-failed', new Error(`Authorization failed: ${authorizationError} - ${description}`))
+      return
+    }
     if (!code) {
       res.status(400).send('Error: No authorization code received')
       return
@@ -865,15 +873,24 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   })
 
   const waitForAuthCode = (): Promise<string> => {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       if (authCode) {
         resolve(authCode)
         return
       }
 
-      options.events.once('auth-code-received', (code) => {
+      const onFailure = (error: Error) => {
+        options.events.off('auth-code-received', onCode)
+        reject(error)
+      }
+      const onCode = (code: string) => {
+        options.events.off('auth-code-failed', onFailure)
         resolve(code)
-      })
+      }
+      options.events.once('auth-code-received', onCode)
+      // An authorization the user denied never produces a code, and waiting for one holds the
+      // callback port for the life of the process
+      options.events.once('auth-code-failed', onFailure)
     })
   }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -98,9 +98,10 @@ async function runProxy(
     // Store server in outer scope for cleanup
     server = authState.server
 
-    // The owner may have settled on a later candidate port because strangers held earlier ones.
-    // Every instance for this server converges on the same one, so the cached registration still
-    // matches and there is nothing to invalidate.
+    // A stranger on an earlier candidate can push us onto a later port than the one the startup
+    // check compared the cached registration against, so a stale registration can still name the
+    // wrong redirect_uri here. Invalidating unconditionally is not the answer - this runs again on
+    // the post-auth reconnect, and deleting the registration then breaks the code exchange.
     if (authState.actualPort !== callbackPort) {
       log(`Using callback port ${authState.actualPort}`)
       authProvider.setCallbackPort(authState.actualPort)


### PR DESCRIPTION
An independent review of the merged #325/#326/#328/#330 found a critical defect and several ways coordination fails harder than it should. This fixes the critical one and makes the rest degrade instead of exiting.

## Critical: a follower accepted the token the gate had just rejected

`hasUsableTokens` (#330) decides whether a sign-in is needed, and rejects an expired token with no refresh token. The follower's exit condition asked a different question:

```ts
async function tokensOnDisk(hash) {
  const tokens = await readJsonFile(hash, 'tokens.json', OAuthTokensSchema)
  return !!tokens   // "a file exists"
}
```

Demonstrated on one file:

```
hasUsableTokens (gate)    -> false   "a sign-in is needed"
tokensOnDisk   (follower) -> true    "someone already signed in"
```

So on re-authentication a follower immediately reported success, reconnected with the stale token, got a 401, and the SDK opened a tab of its own — carrying that instance's PKCE challenge but the owner's `redirect_uri`. With two or more instances, re-auth after expiry could not succeed. The follower now asks `hasUsableTokens`; they were always the same question.

## Waiting for another instance is no longer fatal

Deciding to wait is a guess about what another process is doing, and every way it can be wrong ended in `exit(1)`: a server that only challenges on POST, a squatter answering the identity probe, a proxy swallowing it. A wait that runs out now logs and continues unaided — the server may not need OAuth, or may challenge and let the 401 handler run. Either beats exiting.

Patience also rises to 3 minutes, since a sign-in involves a human; the previous default was exactly the 30s the comment disclaimed.

## Also

- **Localhost probes bypass the global proxy dispatcher.** `--enable-proxy` installs an `EnvHttpProxyAgent` that does not exempt loopback, so the identity probe went to the corporate proxy and every sibling was mistaken for a stranger — disabling coordination entirely.
- **`--callback-path /.mcp-remote/id` is now rejected.** It was accepted and silently shadowed by the identity route, dropping the authorization code.

## Tests

`coordinateAuth`, the follower loop, the yield step and `serverIssuesAuthChallenge` had **zero** unit coverage, which is why these shipped. Nine new tests cover owner/follower/stranger/wrong-server, the stale-token case, and fail-soft. Two fail against current `main`.

189 unit, 10 e2e.

## Not fixed here

I tried restoring the client-registration invalidation when a stranger pushes the owner to a later port, and it broke the exchange — `authInitializer` runs again on the post-auth reconnect, so invalidating there deletes the registration the exchange needs (`Existing OAuth client information is required`). Reverted, with a comment recording why. Still open, needs the mismatch check rather than a blanket invalidate.
