### PR TITLE
Verifier files clean up

### DIFF
--- a/src/lib/mcp-auth-config.test.ts
+++ b/src/lib/mcp-auth-config.test.ts
@@ -11,14 +11,22 @@ vi.mock('./utils', () => ({
   getServerUrlHash: () => 'test-hash',
 }))
 
+let configDir: string
+
+beforeEach(async () => {
+  configDir = await fs.mkdtemp(path.join(os.tmpdir(), 'mcp-remote-config-'))
+  process.env.MCP_REMOTE_CONFIG_DIR = configDir
+})
+
+afterEach(async () => {
+  delete process.env.MCP_REMOTE_CONFIG_DIR
+  await fs.rm(configDir, { recursive: true, force: true })
+})
+
 describe('Feature: Config file writes', () => {
   const hash = 'write-test'
   const filename = 'tokens.json'
-  const target = getConfigFilePath(hash, filename)
-
-  afterEach(async () => {
-    await fs.unlink(target).catch(() => {})
-  })
+  const target = () => getConfigFilePath(hash, filename)
 
   it('Scenario: A reader never observes a half-written file', async () => {
     // Given a payload large enough that a plain writeFile spans several syscalls.
@@ -30,7 +38,7 @@ describe('Feature: Config file writes', () => {
     let torn = false
     const poll = setInterval(() => {
       try {
-        JSON.parse(require('fs').readFileSync(target, 'utf-8'))
+        JSON.parse(require('fs').readFileSync(target(), 'utf-8'))
       } catch (error: any) {
         // ENOENT is fine - the file simply is not there yet. A parse error is not.
         if (error.code !== 'ENOENT') torn = true
@@ -42,14 +50,14 @@ describe('Feature: Config file writes', () => {
 
     // Then every observation was either "absent" or "complete"
     expect(torn).toBe(false)
-    const written = JSON.parse(await fs.readFile(target, 'utf-8'))
+    const written = JSON.parse(await fs.readFile(target(), 'utf-8'))
     expect(written.access_token).toHaveLength(5_000_000)
   })
 
   it('Scenario: No temp files are left behind', async () => {
     await writeJsonFile(hash, filename, { access_token: 'a' })
 
-    const dir = path.dirname(target)
+    const dir = path.dirname(target())
     const leftovers = (await fs.readdir(dir)).filter((f) => f.startsWith(`${filename}`) && f.endsWith('.tmp'))
     expect(leftovers).toEqual([])
   })
@@ -57,7 +65,7 @@ describe('Feature: Config file writes', () => {
   it('Scenario: The file stays owner-only', async () => {
     await writeJsonFile(hash, filename, { access_token: 'a' })
 
-    const stat = await fs.stat(target)
+    const stat = await fs.stat(target())
     // The temp file carries mode 0o600 through the rename
     expect(stat.mode & 0o777).toBe(0o600)
   })
@@ -68,11 +76,11 @@ describe('Feature: Sweeping files nothing will name again', () => {
   const prefix = 'code_verifier_'
 
   const write = async (filename: string, ageMs: number) => {
-    const target = getConfigFilePath(hash, filename)
+    const filePath = getConfigFilePath(hash, filename)
     await writeJsonFile(hash, filename, 'verifier')
     const when = new Date(Date.now() - ageMs)
-    await fs.utimes(target, when, when)
-    return target
+    await fs.utimes(filePath, when, when)
+    return filePath
   }
 
   it('Scenario: An abandoned flow leaves nothing behind, a live one keeps its file', async () => {

--- a/src/lib/mcp-auth-config.test.ts
+++ b/src/lib/mcp-auth-config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { writeJsonFile, readJsonFile, getConfigFilePath } from './mcp-auth-config'
+import { writeJsonFile, readJsonFile, getConfigFilePath, deleteStaleConfigFiles } from './mcp-auth-config'
 
 vi.mock('./utils', () => ({
   log: vi.fn(),
@@ -60,5 +60,34 @@ describe('Feature: Config file writes', () => {
     const stat = await fs.stat(target)
     // The temp file carries mode 0o600 through the rename
     expect(stat.mode & 0o777).toBe(0o600)
+  })
+})
+
+describe('Feature: Sweeping files nothing will name again', () => {
+  const hash = 'sweep-test'
+  const prefix = 'code_verifier_'
+
+  const write = async (filename: string, ageMs: number) => {
+    const target = getConfigFilePath(hash, filename)
+    await writeJsonFile(hash, filename, 'verifier')
+    const when = new Date(Date.now() - ageMs)
+    await fs.utimes(target, when, when)
+    return target
+  }
+
+  it('Scenario: An abandoned flow leaves nothing behind, a live one keeps its file', async () => {
+    const abandoned = await write(`${prefix}old.txt`, 60 * 60 * 1000)
+    const inFlight = await write(`${prefix}fresh.txt`, 0)
+    const unrelated = await write('tokens.json', 60 * 60 * 1000)
+
+    await deleteStaleConfigFiles(hash, prefix, 10 * 60 * 1000)
+
+    await expect(fs.access(abandoned)).rejects.toThrow()
+    await expect(fs.access(inFlight)).resolves.toBeUndefined()
+    // The sweep stays inside the prefix it was given
+    await expect(fs.access(unrelated)).resolves.toBeUndefined()
+
+    await fs.unlink(inFlight).catch(() => {})
+    await fs.unlink(unrelated).catch(() => {})
   })
 })

--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -78,13 +78,6 @@ export async function deleteConfigFile(serverUrlHash: string, filename: string):
 }
 
 /**
- * Reads a JSON file and parses it with the provided schema
- * @param serverUrlHash The hash of the server URL
- * @param filename The name of the file to read
- * @param schema The schema to validate against
- * @returns The parsed file content or undefined if the file doesn't exist
- */
-/**
  * Removes this server's config files with the given prefix that are older than maxAgeMs
  *
  * A filename carrying a one-off identifier is never written again, so abandoned ones would stay
@@ -119,6 +112,13 @@ export async function deleteStaleConfigFiles(serverUrlHash: string, prefix: stri
   }
 }
 
+/**
+ * Reads a JSON file and parses it with the provided schema
+ * @param serverUrlHash The hash of the server URL
+ * @param filename The name of the file to read
+ * @param schema The schema to validate against
+ * @returns The parsed file content or undefined if the file doesn't exist
+ */
 export async function readJsonFile<T>(serverUrlHash: string, filename: string, schema: any): Promise<T | undefined> {
   try {
     await ensureConfigDir()

--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -84,6 +84,41 @@ export async function deleteConfigFile(serverUrlHash: string, filename: string):
  * @param schema The schema to validate against
  * @returns The parsed file content or undefined if the file doesn't exist
  */
+/**
+ * Removes this server's config files with the given prefix that are older than maxAgeMs
+ *
+ * A filename carrying a one-off identifier is never written again, so abandoned ones would stay
+ * forever. The age check leaves alone any file a flow still in progress may need.
+ * @param serverUrlHash The hash of the server URL
+ * @param prefix The filename prefix to sweep
+ * @param maxAgeMs How old a file must be before it is removed
+ */
+export async function deleteStaleConfigFiles(serverUrlHash: string, prefix: string, maxAgeMs: number): Promise<void> {
+  try {
+    const configDir = getConfigDir()
+    const cutoff = Date.now() - maxAgeMs
+    const entries = await fs.readdir(configDir)
+
+    await Promise.all(
+      entries
+        .filter((entry) => entry.startsWith(`${serverUrlHash}_${prefix}`))
+        .map(async (entry) => {
+          const filePath = path.join(configDir, entry)
+          try {
+            if ((await fs.stat(filePath)).mtimeMs > cutoff) return
+            await fs.unlink(filePath)
+            debugLog(`Removed stale config file: ${entry}`)
+          } catch (error) {
+            // Another instance may be sweeping the same directory
+            debugLog(`Could not remove stale config file ${entry}`, error)
+          }
+        }),
+    )
+  } catch (error) {
+    debugLog('Could not sweep stale config files', error)
+  }
+}
+
 export async function readJsonFile<T>(serverUrlHash: string, filename: string, schema: any): Promise<T | undefined> {
   try {
     await ensureConfigDir()

--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -202,6 +202,15 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       expect(mockReadTextFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`, expect.any(String))
     })
 
+    it('should not leave its verifier behind once the flow has produced tokens', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      await provider.saveTokens({ access_token: 'token', token_type: 'Bearer' } as any)
+
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', `code_verifier_${provider.state()}.txt`)
+      expect(vi.mocked(mcpAuthConfig.deleteStaleConfigFiles)).toHaveBeenCalledWith('test-hash', 'code_verifier_', expect.any(Number))
+    })
+
     it('should read the verifier of the flow a code came from, not its own', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)
       // A tab opened by an instance the host has since stopped

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -7,7 +7,7 @@ import {
   OAuthTokensSchema,
 } from '@modelcontextprotocol/sdk/shared/auth.js'
 import type { OAuthProviderOptions, StaticOAuthClientMetadata } from './types'
-import { readJsonFile, writeJsonFile, readTextFile, writeTextFile, deleteConfigFile } from './mcp-auth-config'
+import { readJsonFile, writeJsonFile, readTextFile, writeTextFile, deleteConfigFile, deleteStaleConfigFiles } from './mcp-auth-config'
 import { openBrowser } from './open-browser'
 import { StaticOAuthClientInformationFull } from './types'
 import { log, debugLog, buildRedirectUrl, MCP_REMOTE_VERSION } from './utils'
@@ -31,6 +31,11 @@ type OAuthTokensWithExpiresAt = z.infer<typeof OAuthTokensWithExpiresAtSchema>
 
 /** The shape of the state we issue, and the only shape accepted into a config filename. */
 const ISSUED_STATE = /^[A-Za-z0-9-]{1,64}$/
+
+const CODE_VERIFIER_PREFIX = 'code_verifier_'
+
+/** How long a flow may still be in progress, and its verifier still needed. */
+const ABANDONED_FLOW_AGE_MS = 10 * 60 * 1000
 
 /**
  * Implements the OAuthClientProvider interface for Node.js environments.
@@ -397,6 +402,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
 
     await writeJsonFile(this.serverUrlHash, 'tokens.json', tokensToSave)
+
+    // The flow is over, and its verifier is named after a state nothing will use again
+    await deleteConfigFile(this.serverUrlHash, this.codeVerifierFile(this.flowState))
+    await deleteStaleConfigFiles(this.serverUrlHash, CODE_VERIFIER_PREFIX, ABANDONED_FLOW_AGE_MS)
   }
 
   /**
@@ -461,7 +470,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   }
 
   private codeVerifierFile(state: string): string {
-    return `code_verifier_${state}.txt`
+    return `${CODE_VERIFIER_PREFIX}${state}.txt`
   }
 
   /**


### PR DESCRIPTION
I took a final look at the code and realized that I introduced regression for verifier files in https://github.com/geelen/mcp-remote/pull/329
They'll keep accumulating on user's side

Each one is quite a small thing - like 43 bytes per file - but I thought it would be nice to keep things clean