### PR TITLE
Forward tools/list answers that carry no tool list

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -656,6 +656,16 @@ describe('Feature: Tool Filtering with Ignore Patterns', () => {
 })
 
 describe('Feature: MCP Proxy', () => {
+  const mockTransport = () =>
+    ({
+      send: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      onmessage: vi.fn(),
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+    }) as unknown as Transport
+
   it('Scenario: Proxy initialize message from client to server', async () => {
     // Given mock transports for client and server
     const mockTransportToClient = {
@@ -1051,6 +1061,93 @@ describe('Feature: MCP Proxy', () => {
             { name: 'listTasks', description: 'List all tasks' },
           ],
         },
+      }),
+    )
+  })
+
+  it('Scenario: Forward an error response to tools/list instead of dropping it', async () => {
+    // Given a proxy between mock transports
+    const mockTransportToClient = mockTransport()
+    const mockTransportToServer = mockTransport()
+
+    mcpProxy({
+      transportToClient: mockTransportToClient,
+      transportToServer: mockTransportToServer,
+      ignoredTools: ['delete*'],
+    })
+
+    // And a tools/list request from the client
+    mockTransportToClient.onmessage!({ jsonrpc: '2.0', id: 2, method: 'tools/list' } as any)
+
+    // When the server answers it with a JSON-RPC error rather than a result
+    mockTransportToServer.onmessage!({
+      jsonrpc: '2.0',
+      id: 2,
+      error: { code: -32600, message: 'Session not initialized' },
+    } as any)
+
+    // Then the error reaches the client, rather than the request going unanswered
+    expect(mockTransportToClient.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 2,
+        error: { code: -32600, message: 'Session not initialized' },
+      }),
+    )
+  })
+
+  it('Scenario: Forward a tools/list result that carries no tools', async () => {
+    // Given a proxy between mock transports
+    const mockTransportToClient = mockTransport()
+    const mockTransportToServer = mockTransport()
+
+    mcpProxy({
+      transportToClient: mockTransportToClient,
+      transportToServer: mockTransportToServer,
+      ignoredTools: ['delete*'],
+    })
+
+    // And a tools/list request from the client
+    mockTransportToClient.onmessage!({ jsonrpc: '2.0', id: 3, method: 'tools/list' } as any)
+
+    // When the server answers with a result that omits the tools array
+    mockTransportToServer.onmessage!({ jsonrpc: '2.0', id: 3, result: {} } as any)
+
+    // Then the result is forwarded untouched
+    expect(mockTransportToClient.send).toHaveBeenCalledWith(expect.objectContaining({ id: 3, result: {} }))
+  })
+
+  it('Scenario: A server-initiated request does not consume a pending request with the same id', async () => {
+    // Given a proxy between mock transports
+    const mockTransportToClient = mockTransport()
+    const mockTransportToServer = mockTransport()
+
+    mcpProxy({
+      transportToClient: mockTransportToClient,
+      transportToServer: mockTransportToServer,
+      ignoredTools: ['delete*'],
+    })
+
+    // And an in-flight tools/list request from the client
+    mockTransportToClient.onmessage!({ jsonrpc: '2.0', id: 1, method: 'tools/list' } as any)
+
+    // When the server sends a request of its own that happens to reuse id 1, the two directions
+    // numbering their requests independently
+    mockTransportToServer.onmessage!({ jsonrpc: '2.0', id: 1, method: 'ping' } as any)
+
+    // Then the ping reaches the client untouched
+    expect(mockTransportToClient.send).toHaveBeenCalledWith(expect.objectContaining({ id: 1, method: 'ping' }))
+
+    // And the client's request is still pending, so its real answer is filtered as configured
+    mockTransportToServer.onmessage!({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { tools: [{ name: 'deleteTask' }, { name: 'listTasks' }] },
+    } as any)
+
+    expect(mockTransportToClient.send).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 1,
+        result: { tools: [{ name: 'listTasks' }] },
       }),
     )
   })

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1152,6 +1152,44 @@ describe('Feature: MCP Proxy', () => {
     )
   })
 
+  it('Scenario: Requests wait for the initialized notification to be delivered', async () => {
+    // Given a server that takes a moment to accept the initialized notification
+    const mockTransportToClient = mockTransport()
+    const sent: string[] = []
+    let releaseInitialized: () => void = () => {}
+    const mockTransportToServer = {
+      ...mockTransport(),
+      send: vi.fn().mockImplementation(async (message: any) => {
+        if (message.method === 'notifications/initialized') {
+          await new Promise<void>((resolve) => {
+            releaseInitialized = resolve
+          })
+        }
+        sent.push(message.method ?? String(message.id))
+      }),
+    } as unknown as Transport
+
+    mcpProxy({
+      transportToClient: mockTransportToClient,
+      transportToServer: mockTransportToServer,
+      ignoredTools: [],
+    })
+
+    // When the client sends the notification and its first requests back to back
+    mockTransportToClient.onmessage!({ jsonrpc: '2.0', method: 'notifications/initialized' } as any)
+    mockTransportToClient.onmessage!({ jsonrpc: '2.0', id: 1, method: 'tools/list' } as any)
+    mockTransportToClient.onmessage!({ jsonrpc: '2.0', id: 2, method: 'resources/list' } as any)
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // Then neither request has been sent yet
+    expect(sent).toEqual([])
+
+    // And once the notification lands, they follow in the order the client sent them
+    releaseInitialized()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+    expect(sent).toEqual(['notifications/initialized', 'tools/list', 'resources/list'])
+  })
+
   it('Scenario: Block tools/call for ignored tools with delete* filter', async () => {
     // Given mock transports for client and server
     const mockTransportToClient = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -93,6 +93,15 @@ export function log(str: string, ...rest: unknown[]) {
 type Message = any
 const MESSAGE_BLOCKED = Symbol('MessageBlocked')
 
+/** How long the client's first requests wait on `notifications/initialized` before going anyway. */
+const LIFECYCLE_BARRIER_TIMEOUT_MS = 10_000
+
+/** A timer that never keeps the process alive on its own. */
+const sleep = (ms: number) =>
+  new Promise<void>((resolve) => {
+    setTimeout(resolve, ms).unref?.()
+  })
+
 const isMessageBlocked = (value: any): value is typeof MESSAGE_BLOCKED => value === MESSAGE_BLOCKED
 
 export function createMessageTransformer({
@@ -173,6 +182,7 @@ export function mcpProxy({
   let lastInitialize: Message | null = null
   let reinitSeq = 0
   const pendingReinit = new Map<string, (message: Message) => void>()
+  let initializedDelivered: Promise<unknown> | null = null
 
   const messageTransformer = createMessageTransformer({
     transformRequestFunction: (request: Message) => {
@@ -242,7 +252,7 @@ export function mcpProxy({
       lastInitialize = message
     }
 
-    sendToServer(message)
+    forwardInOrder(message)
   }
 
   transportToServer.onmessage = (_message) => {
@@ -386,6 +396,37 @@ export function mcpProxy({
     // per session - subscriptions, roots, progress tokens - is quietly gone. The
     // spec mandates the new session anyway; there is no way to replay that state.
     log(`Re-established session ${transportToServer.sessionId ?? '(none)'} after server expiry`)
+  }
+
+  /**
+   * Forwards a message, keeping the client's requests behind `notifications/initialized`.
+   *
+   * Every forward here is an independent POST, and a client sends the notification and its first
+   * requests back to back, so without this they race - and a server that enforces the lifecycle
+   * answers whichever request wins with "Session not initialized". The spec puts the same rule on
+   * the client, which it honours over stdio; only the proxy was re-ordering it on the wire (see
+   * https://github.com/geelen/mcp-remote/issues/310).
+   *
+   * Nothing else is serialized. `send` for a JSON-answering server does not resolve until that
+   * request's response has been read, so ordering every message this way would turn concurrent
+   * requests into sequential ones.
+   */
+  function forwardInOrder(message: Message) {
+    if (message.method === 'notifications/initialized') {
+      // Bounded, because a server that never answers the notification must not leave every later
+      // request queued behind it forever - racing ahead is the lesser failure.
+      initializedDelivered = Promise.race([sendToServer(message), sleep(LIFECYCLE_BARRIER_TIMEOUT_MS)])
+      return
+    }
+
+    if (initializedDelivered) {
+      // Continuations resume in the order they were queued, so this preserves the client's order
+      // among the messages waiting on it, not just their order relative to the notification.
+      void initializedDelivered.then(() => sendToServer(message))
+      return
+    }
+
+    void sendToServer(message)
   }
 
   async function sendToServer(message: Message) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -92,6 +92,7 @@ export function log(str: string, ...rest: unknown[]) {
 
 type Message = any
 const MESSAGE_BLOCKED = Symbol('MessageBlocked')
+
 const isMessageBlocked = (value: any): value is typeof MESSAGE_BLOCKED => value === MESSAGE_BLOCKED
 
 export function createMessageTransformer({
@@ -101,22 +102,50 @@ export function createMessageTransformer({
   transformRequestFunction?: null | ((request: Message) => Message | typeof MESSAGE_BLOCKED)
   transformResponseFunction?: null | ((request: Message, response: Message) => Message)
 } = {}) {
-  const pendingRequests = new Map<string, Message>()
+  const pendingRequests = new Map<string | number, Message>()
+
+  /**
+   * A request is the only thing worth remembering, and the only thing worth pairing a response to.
+   *
+   * Both directions carry messages with an `id` that are *not* requests - a response the client
+   * sends back to a server-initiated call, for one - and the two directions number their requests
+   * independently, so recording those would let one side's id collide with the other's and pair a
+   * response with a message that never asked for it.
+   */
+  const isRequest = (message: Message) => message?.id != null && message.method !== undefined
+  const isResponse = (message: Message) => message?.id != null && message.method === undefined
+
+  /**
+   * Runs a transform, falling back to the untouched message if it throws.
+   *
+   * A transform is a convenience; delivery is not. Letting one throw here would abort the
+   * `onmessage` handler that was about to forward the message, so a client would be left waiting
+   * on a request that was in fact answered (see https://github.com/geelen/mcp-remote/issues/310).
+   */
+  const applyTransform = (transform: () => Message, message: Message) => {
+    try {
+      return transform()
+    } catch (error) {
+      log('Error transforming message, forwarding it unchanged:', error)
+      debugLog('Message transform failed', { id: message?.id, method: message?.method, error })
+      return message
+    }
+  }
 
   const interceptRequest = (message: Message) => {
-    const messageId = message.id
-    if (!messageId) return message
-    pendingRequests.set(messageId, message)
-    return transformRequestFunction?.(message) ?? message
+    if (!isRequest(message)) return message
+    pendingRequests.set(message.id, message)
+    if (!transformRequestFunction) return message
+    return applyTransform(() => transformRequestFunction(message) ?? message, message)
   }
 
   const interceptResponse = (message: Message) => {
-    const messageId = message.id
-    if (!messageId) return message
-    const originalRequest = pendingRequests.get(messageId)
+    if (!isResponse(message)) return message
+    const originalRequest = pendingRequests.get(message.id)
     if (!originalRequest) return message
-    pendingRequests.delete(messageId)
-    return transformResponseFunction?.(originalRequest, message) ?? message
+    pendingRequests.delete(message.id)
+    if (!transformResponseFunction) return message
+    return applyTransform(() => transformResponseFunction(originalRequest, message) ?? message, message)
   }
 
   return {
@@ -168,16 +197,20 @@ export function mcpProxy({
       return request
     },
     transformResponseFunction: (req: Message, res: Message) => {
-      if (req.method === 'tools/list') {
-        return {
-          ...res,
-          result: {
-            ...res.result,
-            tools: res.result.tools.filter((tool: any) => shouldIncludeTool(ignoredTools, tool.name)),
-          },
-        }
+      if (req.method !== 'tools/list') return res
+      // Not every answer to tools/list carries a tool list: a JSON-RPC error response has no
+      // `result` at all, and a server may answer with one that omits `tools`. Filtering either
+      // used to throw, and the throw took the forward down with it, so the client was left with
+      // no answer rather than the error the server actually sent (see issues #164 and #310).
+      const tools = res.result?.tools
+      if (!Array.isArray(tools)) return res
+      return {
+        ...res,
+        result: {
+          ...res.result,
+          tools: tools.filter((tool: any) => shouldIncludeTool(ignoredTools, tool.name)),
+        },
       }
-      return res
     },
   })
 


### PR DESCRIPTION
Fixes #310. Fixes #164.

A `tools/list` answer that carries no tool list used to throw inside `transportToServer.onmessage`, and the throw took the forward down with it — so the client got no answer at all for that request id.

### The crash

`transformResponseFunction` assumed every answer to `tools/list` has `result.tools`. A JSON-RPC error response has no `result`, and a server may answer with a result that omits `tools`. Three changes:

- the tools filter bails out unless `result.tools` is an array
- transforms now run through `applyTransform`, which falls back to the untouched message if one throws. A transform is a convenience; delivery is not
- `interceptRequest` / `interceptResponse` discriminate requests from responses (`id` **and** `method`) rather than keying off any truthy `id`

That last one fixes two latent bugs of its own: the two directions number their requests independently, so a server-initiated `ping` with id 1 used to consume the pending entry for the client's own in-flight id-1 request (its answer then went unfiltered); and the client's replies to server requests accumulated in the map forever. It also stops `id: 0` — which Claude Desktop uses for `initialize` — being skipped as falsy.

### The ordering race

Each forward is an independent POST, and a client sends `notifications/initialized` and its first requests back to back, so they could reach the server out of order — and a server that enforces the lifecycle answers whichever request won with `-32600 Session not initialized`.

`forwardInOrder` holds later messages behind the notification's send, bounded at 10s so a server that never answers it cannot wedge the proxy. Deliberately nothing else is serialized: for a JSON-answering server the SDK's `send()` does not resolve until that request's response has been read, so ordering every message would turn concurrent requests into sequential ones.

### Verification

Four new scenarios, each confirmed to fail on `main` and pass here. Full suite 203/203, lint clean.

End to end against a stub that answers `tools/list` with a JSON-RPC error:

| server answers over | before | after |
| --- | --- | --- |
| SSE | **client hangs — response dropped entirely** | server's real `-32600` |
| plain JSON | fabricated `-32001 Cannot read properties of undefined` | server's real `-32600` |

Worth noting for the record: the silent drop only happens in SSE mode. When the server answers with plain JSON the SDK dispatches inside `send()`, so the throw was at least caught and turned into a (wrong) `-32001`. #310 describes it as always silent.

Also re-ran `https://knowledge-mcp.global.api.aws` end to end — initialize, `tools/list` (5 tools) and `resources/list` all fine.
