### PR TITLE
fix: stop mcp-remote-client replacing the dispatcher that settles its own requests

### DIFF
--- a/src/client.ts
+++ b/src/client.ts
@@ -25,6 +25,7 @@ import {
 } from './lib/utils'
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
 import { createLazyAuthCoordinator, hasUsableTokens, serverIssuesAuthChallenge } from './lib/coordination'
+import { attachClientDiagnostics } from './lib/client-diagnostics'
 
 /**
  * Main function to run the client
@@ -134,19 +135,8 @@ async function runClient(
     // Connect to remote server with lazy authentication
     const transport = await connectToRemoteServer(client, serverUrl, authProvider, headers, authInitializer, transportStrategy)
 
-    // Set up message and error handlers
-    transport.onmessage = (message) => {
-      log('Received message:', JSON.stringify(message, null, 2))
-    }
-
-    transport.onerror = (error) => {
-      log('Transport error:', error)
-    }
-
-    transport.onclose = () => {
-      log('Connection closed.')
-      process.exit(0)
-    }
+    // Log what arrives without displacing the dispatcher client.connect() installed
+    attachClientDiagnostics(client, transport, () => process.exit(0))
 
     // Set up cleanup handler
     const cleanup = async () => {

--- a/src/lib/client-diagnostics.test.ts
+++ b/src/lib/client-diagnostics.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import { Server } from '@modelcontextprotocol/sdk/server/index.js'
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js'
+import { ListToolsRequestSchema, ListToolsResultSchema } from '@modelcontextprotocol/sdk/types.js'
+import { attachClientDiagnostics } from './client-diagnostics'
+
+const TOOLS = [{ name: 'search', description: 'Search', inputSchema: { type: 'object' as const } }]
+
+/** A client and server talking over a linked in-memory pair, connected the way the CLI connects them. */
+async function connectedPair() {
+  const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair()
+
+  const server = new Server({ name: 'stub', version: '1.0.0' }, { capabilities: { tools: {} } })
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: TOOLS }))
+  await server.connect(serverTransport)
+
+  const client = new Client({ name: 'mcp-remote', version: '0.0.0' }, { capabilities: {} })
+  await client.connect(clientTransport)
+
+  return { client, server, clientTransport }
+}
+
+describe('Feature: Client diagnostics', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('Scenario: A request still resolves once the diagnostics are attached', async () => {
+    // Given a connected client
+    const { client, clientTransport } = await connectedPair()
+
+    // When the diagnostics are attached after the connection is established
+    attachClientDiagnostics(client, clientTransport, () => {})
+
+    // Then a request still settles, rather than waiting out the SDK's request timeout
+    const tools = await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+    expect(tools.tools.map((tool) => tool.name)).toEqual(['search'])
+
+    await client.close()
+  })
+
+  it('Scenario: Received messages are logged', async () => {
+    // Given a connected client with diagnostics attached
+    const { client, clientTransport } = await connectedPair()
+    attachClientDiagnostics(client, clientTransport, () => {})
+
+    // When a request is answered
+    await client.request({ method: 'tools/list' }, ListToolsResultSchema)
+
+    // Then the response was narrated as well as delivered
+    const logged = vi.mocked(console.error).mock.calls.map((call) => call.join(' '))
+    expect(logged.some((line) => line.includes('Received message:') && line.includes('search'))).toBe(true)
+
+    await client.close()
+  })
+
+  it('Scenario: Closing the connection reports it once', async () => {
+    // Given a connected client with diagnostics attached
+    const { client, server, clientTransport } = await connectedPair()
+    const onClose = vi.fn()
+    attachClientDiagnostics(client, clientTransport, onClose)
+
+    // When the other end goes away
+    await server.close()
+    await new Promise((resolve) => setTimeout(resolve, 10))
+
+    // Then the caller is told exactly once
+    expect(onClose).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/lib/client-diagnostics.ts
+++ b/src/lib/client-diagnostics.ts
@@ -1,0 +1,36 @@
+import type { Client } from '@modelcontextprotocol/sdk/client/index.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
+import { log } from './utils'
+
+/**
+ * Makes a connected client narrate what it receives, without breaking what it receives it with.
+ *
+ * `client.connect()` installs the handler that settles `client.request()` on `transport.onmessage`,
+ * so assigning a logger there afterwards silently removes it: responses still arrive and are still
+ * printed, but nothing resolves the pending request, and every call fails on the SDK's 60 second
+ * timeout while the answer sits in the log (see https://github.com/geelen/mcp-remote/issues/324).
+ * Delegating to the handler that is already there keeps both.
+ *
+ * Errors and closes need no such care - `Protocol` exposes hooks of its own for those, and using
+ * them leaves its transport wiring alone.
+ *
+ * @param client The connected client
+ * @param transport The transport it was connected with
+ * @param onClose Called after the connection closes and the client has been told
+ */
+export function attachClientDiagnostics(client: Client, transport: Transport, onClose: () => void): void {
+  const dispatch = transport.onmessage
+  transport.onmessage = (message, extra) => {
+    log('Received message:', JSON.stringify(message, null, 2))
+    dispatch?.(message, extra)
+  }
+
+  client.onerror = (error) => {
+    log('Transport error:', error)
+  }
+
+  client.onclose = () => {
+    log('Connection closed.')
+    onClose()
+  }
+}


### PR DESCRIPTION
Fixes #324. Fixes #316.

`mcp-remote-client` connected a `Client` and then assigned its own logger to `transport.onmessage`. `client.connect()` installs the handler that settles `client.request()` on exactly that property, so the assignment removed it: responses arrived, got printed, and settled nothing. Both self-checks then failed on the SDK's 60 second request timeout while the answer sat in the log, and the process still exited `0`, so the only visible symptom was two lost minutes.

### The fix

`attachClientDiagnostics` delegates to the handler that is already there instead of replacing it. Errors and closes move to `client.onerror` / `client.onclose` — `Protocol` exposes hooks for those, so the transport wiring is left alone entirely.

It lives in `src/lib/client-diagnostics.ts` rather than inline, because `src/client.ts` parses argv at import time and so cannot be unit tested.

### Verification

Three scenarios over a linked in-memory client/server pair. The first two hang and fail on the old code; all three pass on this branch.

Measured end to end against `https://knowledge-mcp.global.api.aws`:

| | before | after |
| --- | --- | --- |
| wall clock | **121s** | **2s** |
| `tools/list` | `-32001: Request timed out` | 5 tools |
| `resources/list` | `-32001: Request timed out` | returns |

`Received message:` is still logged for every message, so nothing is lost from the diagnostic output.

Note for #316: this is the second of the two problems reported there. The first — the OAuth callback listener not binding on Windows when the flow is triggered by a mid-session `tools/call` — is the runtime re-auth gap tracked in #248 / #133 / #286, and is not addressed here.
