### PR TITLE
fix: keep the headers the SDK set on the SSE request

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -6,8 +6,10 @@ import {
   setupOAuthCallbackServerWithLongPoll,
   getServerUrlHash,
   calculateDefaultPort,
+  mergeHeaders,
   MCP_REMOTE_VERSION,
 } from './utils'
+import { Headers as UndiciHeaders } from 'undici'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
 import { EventEmitter } from 'events'
@@ -1841,6 +1843,52 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
     } finally {
       await new Promise<void>((resolve) => blocker.close(() => resolve()))
     }
+  })
+})
+
+describe('Feature: Merging headers for the SSE request', () => {
+  it('Scenario: Keep the headers the SDK set, whichever Headers class built them', () => {
+    // Given headers from the SDK, which builds them with the global class rather than undici's
+    const fromSdk = new globalThis.Headers({ 'mcp-protocol-version': '2025-06-18' })
+
+    // When they are merged
+    const merged = mergeHeaders(fromSdk, { Accept: 'text/event-stream' })
+
+    // Then they survive, rather than being spread away to nothing
+    expect(merged).toEqual({ 'mcp-protocol-version': '2025-06-18', Accept: 'text/event-stream' })
+  })
+
+  it('Scenario: Accept undici Headers just the same', () => {
+    const merged = mergeHeaders(new UndiciHeaders({ 'x-from-undici': 'yes' }))
+
+    expect(merged).toEqual({ 'x-from-undici': 'yes' })
+  })
+
+  it('Scenario: One header per name, however its writers spelled it', () => {
+    // Given the same header arriving in two cases, as it does when the SDK's lowercased
+    // `authorization` meets the `Authorization` added alongside it
+    const merged = mergeHeaders(new globalThis.Headers({ authorization: 'Bearer stale' }), { Authorization: 'Bearer fresh' })
+
+    // Then only the later one is sent. Emitting both would have fetch join them into
+    // "Bearer stale, Bearer fresh", which no server accepts.
+    expect(Object.keys(merged)).toEqual(['Authorization'])
+    expect(merged.Authorization).toBe('Bearer fresh')
+  })
+
+  it('Scenario: A custom header keeps the case it was written in', () => {
+    // Given a server that matches its header names case-sensitively
+    const merged = mergeHeaders(new globalThis.Headers({ accept: 'text/event-stream' }), { Company: 'ACME', TenantId: 'abc' })
+
+    // Then --header values are passed on spelled the way the user spelled them
+    expect(merged.Company).toBe('ACME')
+    expect(merged.TenantId).toBe('abc')
+  })
+
+  it('Scenario: Accept the other shapes fetch allows', () => {
+    expect(mergeHeaders(undefined)).toEqual({})
+    expect(mergeHeaders({ a: '1' }, undefined, { b: '2' })).toEqual({ a: '1', b: '2' })
+    // An array of pairs, whose own `entries()` would yield [index, pair] if it were treated as iterable
+    expect(mergeHeaders([['x-pair', 'value']])).toEqual({ 'x-pair': 'value' })
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -600,6 +600,48 @@ export type AuthInitializer = () => Promise<{
   skipBrowserAuth: boolean
 }>
 
+/** The header shapes `fetch` accepts, plus the `Headers` the SDK actually hands over. */
+type HeaderSource = RequestInit['headers'] | Headers | globalThis.Headers | undefined
+
+function headerEntries(source: HeaderSource): Array<[string, string]> {
+  if (!source) return []
+  // Arrays have `entries` too, so this order matters - theirs yields [index, pair], not [name, value]
+  if (Array.isArray(source)) return source as Array<[string, string]>
+  const iterable = source as { entries?: () => Iterable<[string, string]> }
+  if (typeof iterable.entries === 'function') return [...iterable.entries()]
+  return Object.entries(source as Record<string, string>)
+}
+
+/**
+ * Merges header sources into one plain object, with later sources winning.
+ *
+ * Two things make this less trivial than a spread.
+ *
+ * The sources are different shapes. The SDK hands over a `Headers` built from the *global* class,
+ * while the check here used to be `instanceof Headers` against the one imported from undici - a
+ * different class, so it never matched, and the fallback spread of a `Headers` yields no own
+ * properties at all. Every header the SDK had set was dropped (see
+ * https://github.com/geelen/mcp-remote/issues/157). Duck-typing on `entries` accepts either.
+ *
+ * And the sources disagree about case. `Headers.entries()` lowercases, while `--header` values and
+ * the ones added here keep the case they were written in, so a plain merge emits `authorization`
+ * *and* `Authorization` as separate keys - which `fetch` then joins into a single comma-separated
+ * value that no server will accept. Merging case-insensitively keeps one entry per header, spelled
+ * the way its last writer spelled it, so a server matching on `Company` still sees `Company`.
+ *
+ * @param sources Header collections in precedence order, lowest first
+ * @returns The merged headers
+ */
+export function mergeHeaders(...sources: HeaderSource[]): Record<string, string> {
+  const merged = new Map<string, [string, string]>()
+  for (const source of sources) {
+    for (const [name, value] of headerEntries(source)) {
+      merged.set(name.toLowerCase(), [name, value])
+    }
+  }
+  return Object.fromEntries(merged.values())
+}
+
 /**
  * Creates and connects to a remote server with OAuth authentication
  * @param client The client to connect with
@@ -629,14 +671,12 @@ export async function connectToRemoteServer(
       return Promise.resolve(authProvider?.tokens?.()).then((tokens) =>
         fetch(url, {
           ...init,
-          headers: {
-            ...(init?.headers instanceof Headers
-              ? Object.fromEntries(init?.headers.entries())
-              : (init?.headers as Record<string, string>) || {}),
-            ...headers,
-            ...(tokens?.access_token ? { Authorization: `Bearer ${tokens.access_token}` } : {}),
-            Accept: 'text/event-stream',
-          } as Record<string, string>,
+          headers: mergeHeaders(
+            init?.headers,
+            headers,
+            tokens?.access_token ? { Authorization: `Bearer ${tokens.access_token}` } : undefined,
+            { Accept: 'text/event-stream' },
+          ),
         }),
       )
     },


### PR DESCRIPTION
Fixes #157.

`eventSourceInit.fetch` guarded with `init?.headers instanceof Headers`, but `Headers` there is imported from **undici** while the SDK builds its headers with the **global** class — the SDK imports undici nowhere. The check was therefore always false, execution fell through to the object-spread branch, and spreading a `Headers` yields no own properties:

```
instanceof undici Headers: false
spread result: {}
```

So every header the SDK had set was dropped from the SSE request.

### What that actually cost

Less than it sounds, which is why it went unnoticed for so long. On the initial `GET`, `_commonHeaders` contributes `Authorization` and the `--header` values, and the lines right below re-added both — so the drop was benign there.

It bites on **EventSource reconnects**. Once `initialize` has completed the SDK sets `_protocolVersion`, and `_commonHeaders` starts including `mcp-protocol-version`. Nothing re-adds that one, so every reconnected SSE stream went out without it, and a server that requires the negotiated version rejects it.

The originally reported crash (`Key Symbol(headers list) ... cannot be converted to a ByteString`) is separately gone: on current Node the fallback spread yields `{}` rather than symbol keys, so it no longer throws. This fixes what was left.

### Why not just correct the `instanceof`

Because that turns a silent drop into a broken `Authorization` header. `Headers.entries()` lowercases its names, while `--header` values and the ones added here keep the case they were written in — so a plain merge emits `authorization` **and** `Authorization`, and `fetch` joins them:

```
authorization: "Bearer stale, Bearer fresh"
```

`mergeHeaders` therefore merges case-insensitively, keeping one entry per header spelled the way its last writer spelled it — so a server matching on `Company` still receives `Company`, not `company`.

### Verification

Five scenarios. Two fail against the old code (headers dropped; array-of-pairs shape mishandled), and the case-collision one fails against the *naive* fix — it exists to stop that fix being written later:

```
naive fix → expected [ 'authorization', 'Authorization' ] to deeply equal [ 'Authorization' ]
```

On the wire, against a local SSE server recording `rawHeaders`, with `--transport sse-only --header 'Company: ACME' --header 'Authorization: Bearer USER-TOKEN'`:

```
Accept: text/event-stream
Authorization: Bearer USER-TOKEN
Company: ACME

authorization count: 1
accept count: 1
```

One of each, user casing intact, no comma-joined value.
