### PR TITLE
feat: make network timeouts and IPv4-only connections configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,33 @@ You can specify multiple `--ignore-tool` flags to ignore different patterns. Exa
       ]
 ```
 
+* To change the network timeouts, add `--connect-timeout`, `--headers-timeout` or `--body-timeout`, each with a value in seconds. These apply to every outbound request, including the OAuth ones.
+
+  * `--connect-timeout` bounds establishing the TCP connection (default `10`). Lower it to fail faster on an unreachable server.
+  * `--headers-timeout` bounds waiting for response headers (default `300`).
+  * `--body-timeout` bounds a gap between chunks of a response body (default `300`). This is the one that closes an idle SSE stream after five minutes; pass `0` to disable it for servers that push infrequently.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--connect-timeout",
+        "30",
+        "--body-timeout",
+        "0"
+      ]
+```
+
+* To connect over IPv4 only, add the `--ipv4` flag. Useful when a hostname resolves to both IPv4 and IPv6 addresses but the IPv6 routes silently black-hole rather than being refused — connection attempts then time out instead of failing over, and the request never completes.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--ipv4"
+      ]
+```
+
 ### Transport Strategies
 
 MCP Remote supports different transport strategies when connecting to an MCP server. This allows you to control whether it uses Server-Sent Events (SSE) or HTTP transport, and in what order it tries them.

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -7,6 +7,7 @@ import {
   getServerUrlHash,
   calculateDefaultPort,
   mergeHeaders,
+  parseSecondsOption,
   MCP_REMOTE_VERSION,
 } from './utils'
 import { Headers as UndiciHeaders } from 'undici'
@@ -1889,6 +1890,43 @@ describe('Feature: Merging headers for the SSE request', () => {
     expect(mergeHeaders({ a: '1' }, undefined, { b: '2' })).toEqual({ a: '1', b: '2' })
     // An array of pairs, whose own `entries()` would yield [index, pair] if it were treated as iterable
     expect(mergeHeaders([['x-pair', 'value']])).toEqual({ 'x-pair': 'value' })
+  })
+})
+
+describe('Feature: Network Tuning Options', () => {
+  it('Scenario: Read a duration in seconds as milliseconds', () => {
+    expect(parseSecondsOption(['--connect-timeout', '30'], '--connect-timeout')).toBe(30000)
+    expect(parseSecondsOption(['--connect-timeout', '2.5'], '--connect-timeout')).toBe(2500)
+  })
+
+  it('Scenario: Absent flag leaves the setting alone', () => {
+    // Undefined rather than a default, so an unset flag never installs a dispatcher of its own
+    expect(parseSecondsOption(['--transport', 'sse-only'], '--connect-timeout')).toBeUndefined()
+    expect(parseSecondsOption(['--connect-timeout'], '--connect-timeout')).toBeUndefined()
+  })
+
+  it('Scenario: Zero disables a timeout, but only where that is meaningful', () => {
+    // `--body-timeout 0` is how you keep undici from tearing down an idle SSE stream
+    expect(parseSecondsOption(['--body-timeout', '0'], '--body-timeout', { allowZero: true })).toBe(0)
+    // A zero connect timeout would just mean "never connect", so it is rejected
+    expect(parseSecondsOption(['--connect-timeout', '0'], '--connect-timeout')).toBeUndefined()
+  })
+
+  it('Scenario: Reject values that are not durations', () => {
+    expect(parseSecondsOption(['--connect-timeout', 'soon'], '--connect-timeout')).toBeUndefined()
+    expect(parseSecondsOption(['--connect-timeout', '-5'], '--connect-timeout')).toBeUndefined()
+    expect(parseSecondsOption(['--body-timeout', 'Infinity'], '--body-timeout', { allowZero: true })).toBeUndefined()
+  })
+
+  it('Scenario: Accept the network flags alongside the server URL', async () => {
+    // Given every network flag set at once
+    const result = await parseCommandLineArgs(
+      ['https://example.remote/server', '--connect-timeout', '20', '--body-timeout', '0', '--headers-timeout', '90', '--ipv4'],
+      'Usage: mcp-remote <url>',
+    )
+
+    // Then they are consumed as options rather than mistaken for the URL or the callback port
+    expect(result.serverUrl).toBe('https://example.remote/server')
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -22,7 +22,7 @@ import fs from 'fs'
 import { readFile, rm } from 'fs/promises'
 import path from 'path'
 import { version as MCP_REMOTE_VERSION } from '../../package.json'
-import { EnvHttpProxyAgent, fetch, Headers, RequestInit, setGlobalDispatcher } from 'undici'
+import { Agent, EnvHttpProxyAgent, fetch, Headers, RequestInit, setGlobalDispatcher } from 'undici'
 
 // Global type declaration for typescript
 declare global {
@@ -1073,6 +1073,35 @@ export function calculateDefaultPort(serverUrlHash: string): number {
  * @param usage Usage message to show on error
  * @returns A promise that resolves to an object with parsed serverUrl, callbackPort and headers
  */
+/** The subset of undici dispatcher options this CLI exposes. Shared by both agent flavours. */
+type DispatcherOptions = {
+  connect?: { timeout?: number; family?: number }
+  bodyTimeout?: number
+  headersTimeout?: number
+}
+
+/**
+ * Reads a flag whose value is a duration in seconds, and returns it in milliseconds.
+ *
+ * @param args The command line arguments
+ * @param flag The flag to read
+ * @param options Whether zero is meaningful for this flag - for the timeouts it means "no timeout"
+ * @returns The duration in milliseconds, or undefined if the flag was absent or unusable
+ */
+export function parseSecondsOption(args: string[], flag: string, { allowZero = false } = {}): number | undefined {
+  const index = args.indexOf(flag)
+  if (index === -1 || index >= args.length - 1) return undefined
+
+  const raw = args[index + 1]
+  const seconds = Number(raw)
+  if (!Number.isFinite(seconds) || seconds < 0 || (seconds === 0 && !allowZero)) {
+    log(`Warning: Ignoring invalid ${flag} value: ${raw}. Must be a ${allowZero ? 'non-negative' : 'positive'} number of seconds.`)
+    return undefined
+  }
+
+  return Math.round(seconds * 1000)
+}
+
 export async function parseCommandLineArgs(args: string[], usage: string) {
   if (args.includes('--help') || args.includes('-h')) {
     process.stdout.write(`${usage}\n`)
@@ -1123,11 +1152,42 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     log('Silent mode enabled - stderr output will be suppressed, except when --debug is also enabled')
   }
 
+  // Network tuning. These land on the global undici dispatcher, which both our own `fetch` and the
+  // SDK's `globalThis.fetch` resolve through - the slot is keyed by a registered symbol, so the two
+  // undici copies share it. Without a dispatcher there is no way to reach these settings at all,
+  // which is why people have been patching them in with NODE_OPTIONS (see issues #107 and #263).
+  const connectTimeoutMs = parseSecondsOption(args, '--connect-timeout')
+  const bodyTimeoutMs = parseSecondsOption(args, '--body-timeout', { allowZero: true })
+  const headersTimeoutMs = parseSecondsOption(args, '--headers-timeout', { allowZero: true })
+  const forceIpv4 = args.includes('--ipv4')
+
+  const dispatcherOptions: DispatcherOptions = {}
+  if (connectTimeoutMs !== undefined || forceIpv4) {
+    dispatcherOptions.connect = {
+      ...(connectTimeoutMs !== undefined ? { timeout: connectTimeoutMs } : {}),
+      // Happy-eyeballs tries every A and AAAA record it gets back. On a network where the IPv6
+      // routes are black holes rather than refusals, those attempts time out instead of failing
+      // fast and take the whole request with them, even though the IPv4 addresses are reachable.
+      ...(forceIpv4 ? { family: 4 } : {}),
+    }
+  }
+  if (bodyTimeoutMs !== undefined) dispatcherOptions.bodyTimeout = bodyTimeoutMs
+  if (headersTimeoutMs !== undefined) dispatcherOptions.headersTimeout = headersTimeoutMs
+
+  if (forceIpv4) log('Restricting connections to IPv4')
+  if (connectTimeoutMs !== undefined) log(`Using connect timeout: ${connectTimeoutMs / 1000} seconds`)
+  if (bodyTimeoutMs !== undefined) log(`Using body timeout: ${bodyTimeoutMs === 0 ? 'disabled' : `${bodyTimeoutMs / 1000} seconds`}`)
+  if (headersTimeoutMs !== undefined) {
+    log(`Using headers timeout: ${headersTimeoutMs === 0 ? 'disabled' : `${headersTimeoutMs / 1000} seconds`}`)
+  }
+
   const enableProxy = args.includes('--enable-proxy')
   if (enableProxy) {
     // Use env proxy
-    setGlobalDispatcher(new EnvHttpProxyAgent())
+    setGlobalDispatcher(new EnvHttpProxyAgent(dispatcherOptions))
     log('HTTP proxy support enabled - using system HTTP_PROXY/HTTPS_PROXY environment variables')
+  } else if (Object.keys(dispatcherOptions).length > 0) {
+    setGlobalDispatcher(new Agent(dispatcherOptions))
   }
 
   // Parse transport strategy


### PR DESCRIPTION
Closes #107. Closes #263.

Both issues are the same gap: undici's connection settings were unreachable. `setGlobalDispatcher` was only ever called under `--enable-proxy`, so with no proxy there was no dispatcher to configure, and people worked around it by patching one in through `NODE_OPTIONS` — [#107](https://github.com/geelen/mcp-remote/issues/107) with `new Agent({ bodyTimeout: 0 })`, [#263](https://github.com/geelen/mcp-remote/issues/263) with `new Agent({ connect: { family: 4 } })`.

### New flags

| flag | undici option | default | why |
| --- | --- | --- | --- |
| `--connect-timeout <s>` | `connect.timeout` | 10s | fail fast on an unreachable server (#107's `ConnectTimeoutError`) |
| `--headers-timeout <s>` | `headersTimeout` | 300s | servers that think for a long time before answering |
| `--body-timeout <s>` | `bodyTimeout` | 300s | `0` stops undici tearing down an SSE stream that has been idle five minutes |
| `--ipv4` | `connect.family = 4` | — | hostnames whose IPv6 routes black-hole rather than refuse (#263) |

They compose with `--enable-proxy`: `EnvHttpProxyAgent.Options` extends `Agent.Options`, so the same settings apply on either path. With no flag set, no dispatcher is installed and undici's defaults stand, exactly as before.

### Why this reaches the SDK too

Worth recording, since it isn't obvious: most requests go out through the SDK's `globalThis.fetch`, which is Node's *built-in* undici, not the userland package this imports. They still share one dispatcher, because the slot is keyed by a registered symbol — `Symbol(undici.globalDispatcher.1)` — so `setGlobalDispatcher` from either copy is seen by both. Measured against a black-holed address:

```
baseline globalThis.fetch:            10515 ms
with a 300ms-connect-timeout agent:    1003 ms
```

### Verification

Five parsing scenarios, plus end-to-end runs.

`--connect-timeout` against a black-holed address, showing it drives the real connection attempts:

```
--connect-timeout 1 -> 13650ms
--connect-timeout 4 -> 40643ms
```

`--ipv4` against a server bound only to `[::1]:8797`, reached as `http://localhost:8797`:

| | result |
| --- | --- |
| without `--ipv4` | connects over IPv6, proxy established |
| with `--ipv4` | `ECONNREFUSED` — only 127.0.0.1 is attempted |

One caveat found while measuring: undici's timers are coarse, so a sub-second value rounds up to about 1s. Fine for these flags, but it means `--connect-timeout 0.2` is not meaningfully different from `--connect-timeout 1`.
