### PR TITLE
fix: authorize with the scopes an insufficient_scope challenge asked for

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -114,6 +114,57 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
     })
   })
 
+  describe('scope from a live WWW-Authenticate challenge', () => {
+    it('should keep the scopes a 403 insufficient_scope asked for', async () => {
+      // Given a resource advertising only "read", and a call that turned out to need more
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        protectedResourceMetadata: { resource: 'https://example.com', scopes_supported: ['read'] } as any,
+      })
+
+      // When the SDK re-runs authorization with the scopes the challenge named
+      const authUrl = new URL('https://auth.example.com/authorize')
+      authUrl.searchParams.set('scope', 'read write admin')
+      await provider.redirectToAuthorization(authUrl)
+
+      // Then they survive. Re-requesting "read" would just be refused again.
+      expect(authUrl.searchParams.get('scope')).toBe('read write admin')
+    })
+
+    it('should still impose its own order on the scopes it supplied itself', async () => {
+      // Given a client whose own priority puts the WWW-Authenticate scope above the resource's
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        wwwAuthenticateScope: 'mcp:full',
+        protectedResourceMetadata: { resource: 'https://example.com', scopes_supported: ['read'] } as any,
+      })
+
+      // When the SDK offers the resource metadata scopes, which it prefers and this client does not
+      const authUrl = new URL('https://auth.example.com/authorize')
+      authUrl.searchParams.set('scope', 'read')
+      await provider.redirectToAuthorization(authUrl)
+
+      // Then this client's choice still wins
+      expect(authUrl.searchParams.get('scope')).toBe('mcp:full')
+    })
+
+    it('should let a user-pinned scope override the challenge', async () => {
+      // Given a scope the user pinned because the advertised ones do not work for them
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        staticOAuthClientMetadata: { scope: 'custom:only' } as any,
+        protectedResourceMetadata: { resource: 'https://example.com', scopes_supported: ['read'] } as any,
+      })
+
+      const authUrl = new URL('https://auth.example.com/authorize')
+      authUrl.searchParams.set('scope', 'read write admin')
+      await provider.redirectToAuthorization(authUrl)
+
+      // Then a challenge does not talk them out of it
+      expect(authUrl.searchParams.get('scope')).toBe('custom:only')
+    })
+  })
+
   describe('backward compatibility', () => {
     it('should preserve existing custom scope behavior', () => {
       provider = new NodeOAuthClientProvider({

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -418,13 +418,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       // Ignore errors, metadata is optional
     })
 
-    const effectiveScope = this.getEffectiveScope()
-    if (effectiveScope) {
-      authorizationUrl.searchParams.set('scope', effectiveScope)
-      debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
-    } else {
-      debugLog('Omitting scope parameter from authorization URL (no effective scope)')
-    }
+    this.applyScope(authorizationUrl)
 
     log(`\nPlease authorize this client by visiting:\n${authorizationUrl.toString()}\n`)
 
@@ -434,6 +428,46 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       log('Browser opened automatically.')
     } else {
       log('Could not open a browser automatically. Please copy and paste the URL above into your browser.')
+    }
+  }
+
+  /**
+   * Decides which scope the authorization request asks for.
+   *
+   * The SDK has already put one on the URL, picked - in its order - from a scope it parsed out of a
+   * live `WWW-Authenticate` challenge, the protected resource's `scopes_supported`, or the `scope`
+   * in our own client metadata. The last two originate here, and this client's priority order for
+   * them is not the SDK's, so they are replaced with what `getEffectiveScope` decided.
+   *
+   * A challenge scope does not originate here, and replacing it defeated the one thing it is for: a
+   * 403 `insufficient_scope` names the scopes the call actually needed, the SDK re-runs
+   * authorization asking for them, and overwriting them here re-requested exactly the scope that
+   * had just been refused - so it was refused again and the SDK gave up with "Server returned 403
+   * after trying upscoping" (see https://github.com/geelen/mcp-remote/issues/134).
+   *
+   * A scope the user pinned with `--static-oauth-client-metadata` still wins over both. They set it
+   * because the scopes the server advertises do not work for them, and a challenge is the server
+   * advertising them again.
+   *
+   * @param authorizationUrl The authorization URL to set the scope on, modified in place
+   */
+  private applyScope(authorizationUrl: URL): void {
+    const effectiveScope = this.getEffectiveScope()
+    const requestedScope = authorizationUrl.searchParams.get('scope')
+    const pinnedByUser = !!this.staticOAuthClientMetadata?.scope?.trim()
+    const couldBeOurs = [effectiveScope, this.protectedResourceMetadata?.scopes_supported?.join(' ')]
+
+    if (!pinnedByUser && requestedScope && !couldBeOurs.includes(requestedScope)) {
+      log(`Authorizing with the scope the server asked for: ${requestedScope}`)
+      debugLog('Keeping a scope this client did not supply', { scope: requestedScope, effectiveScope })
+      return
+    }
+
+    if (effectiveScope) {
+      authorizationUrl.searchParams.set('scope', effectiveScope)
+      debugLog('Added scope parameter to authorization URL', { scopes: effectiveScope })
+    } else {
+      debugLog('Omitting scope parameter from authorization URL (no effective scope)')
     }
   }
 


### PR DESCRIPTION
Fixes #134.

Half of what this issue asked for arrived upstream: SDK 1.25.3 answers a 403 `insufficient_scope` by parsing the scopes out of the `WWW-Authenticate` header and re-running authorization with them (`streamableHttp.js:336`). But it never worked through `mcp-remote`, because `redirectToAuthorization` overwrote the scope the SDK had just chosen:

```
SDK sets:      scope=read write admin   (what the challenge asked for)
mcp-remote:    scope=read               (what the resource advertises)
```

So the retry re-requested the exact scope that had just been refused, the server refused it again, and the SDK's own loop guard gave up with `Server returned 403 after trying upscoping`. The upscoping path could never succeed.

### The fix

The SDK picks the URL's scope from one of three places (`authInternal`): a scope parsed from a live challenge, the resource's `scopes_supported`, or the `scope` in our client metadata. The last two originate here, and this client's priority order for them deliberately differs from the SDK's — those still get replaced.

A challenge scope does not originate here, so it is now left alone.

One exception: a scope pinned with `--static-oauth-client-metadata` still wins. Users set that precisely because the scopes the server advertises don't work for them (#53), and a challenge is the server advertising them again.

### Verification

Three scenarios that bracket the fix from both sides:

| | old behaviour | naive fix | this |
| --- | --- | --- | --- |
| keeps a 403's scopes | ✗ | ✓ | ✓ |
| still imposes our order on scopes we supplied | ✓ | ✗ | ✓ |
| user-pinned scope still wins | ✓ | ✗ | ✓ |

The middle two exist to stop this being "fixed" by simply always keeping whatever the SDK put on the URL, which would silently undo both the client's scope precedence and `--static-oauth-client-metadata`.

### Not covered

`sse.js` has no 403 handling at all — only `streamableHttp.js` does. On `--transport sse-only` an `insufficient_scope` response still surfaces as a plain HTTP error. That is an upstream gap rather than something to work around here, and the SSE transport is deprecated in the spec while `http-first` is the default, so I have not tried to patch around it.
