### PR TITLE
fix: stop exchanging tokens in a loop when the server rejects every one

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -190,6 +190,64 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
     })
   })
 
+  describe('token exchange loop protection', () => {
+    const anAccessToken = { access_token: 'at', token_type: 'Bearer', expires_in: 3600 } as any
+
+    /** Saves repeatedly until the brake bites, returning how many got through. */
+    const saveUntilRefused = async (limit = 60) => {
+      for (let attempt = 1; attempt <= limit; attempt++) {
+        try {
+          await provider.saveTokens({ ...anAccessToken })
+        } catch {
+          return attempt
+        }
+      }
+      return undefined
+    }
+
+    it('allows the few refreshes a burst of concurrent requests can legitimately cause', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      for (let i = 0; i < 10; i++) {
+        await expect(provider.saveTokens({ ...anAccessToken })).resolves.toBeUndefined()
+      }
+    })
+
+    it('stops once tokens are issued faster than any token lifetime could explain', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+
+      // A server rejecting every token it is handed makes this unbounded without the brake
+      const refusedAt = await saveUntilRefused()
+
+      expect(refusedAt).toBeDefined()
+      expect(refusedAt).toBeLessThanOrEqual(25)
+    })
+
+    it('does not send the user to a browser while it is refusing to exchange', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+      await saveUntilRefused()
+
+      // Otherwise a refused refresh just becomes a full sign-in, and the storm reappears as tabs
+      await expect(provider.redirectToAuthorization(new URL('https://auth.example.com/authorize'))).rejects.toThrow(/token exchanges/)
+    })
+
+    it('exchanges again once the burst has aged out', async () => {
+      vi.useFakeTimers()
+      try {
+        vi.setSystemTime(new Date('2026-01-01T00:00:00Z'))
+        provider = new NodeOAuthClientProvider(defaultOptions)
+        await saveUntilRefused()
+
+        // The window slides, so a client that stopped hammering is not punished forever
+        vi.setSystemTime(new Date('2026-01-01T00:01:00Z'))
+
+        await expect(provider.saveTokens({ ...anAccessToken })).resolves.toBeUndefined()
+      } finally {
+        vi.useRealTimers()
+      }
+    })
+  })
+
   describe('credential invalidation', () => {
     it('should reset to default scopes after client invalidation', async () => {
       provider = new NodeOAuthClientProvider(defaultOptions)

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -34,6 +34,17 @@ const ISSUED_STATE = /^[A-Za-z0-9-]{1,64}$/
 
 const CODE_VERIFIER_PREFIX = 'code_verifier_'
 
+/**
+ * How many access tokens may be issued inside {@link TOKEN_STORM_WINDOW_MS} before this client
+ * stops going back for more.
+ *
+ * Set well above any legitimate cadence. A token lives minutes at least, and the handful of
+ * refreshes a burst of concurrent requests can trigger is nowhere near this. Reaching it means
+ * something is exchanging tokens in a loop rather than because one expired.
+ */
+const TOKEN_STORM_LIMIT = 20
+const TOKEN_STORM_WINDOW_MS = 30_000
+
 /** How long a flow may still be in progress, and its verifier still needed. */
 const ABANDONED_FLOW_AGE_MS = 10 * 60 * 1000
 
@@ -63,6 +74,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private authorizationServerMetadata: AuthorizationServerMetadata | undefined
   private protectedResourceMetadata: ProtectedResourceMetadata | undefined
   private wwwAuthenticateScope: string | undefined
+  /** When tokens were last written, for spotting an exchange loop. See {@link TOKEN_STORM_LIMIT}. */
+  private recentTokenWrites: number[] = []
   /** In-flight proactive refresh, so concurrent requests share one refresh_token use */
   private refreshInFlight: Promise<OAuthTokensWithExpiresAt | undefined> | null = null
 
@@ -374,7 +387,50 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    * Saves OAuth tokens
    * @param tokens The tokens to save
    */
+  /**
+   * Stops this client taking part in a token exchange loop.
+   *
+   * An authorization server that keeps honouring a refresh token, for a resource server that keeps
+   * rejecting the access tokens it returns, is a loop with nothing to end it: every rejection looks
+   * to the SDK like a token worth refreshing. The SDK breaks that cycle for the request path, but
+   * not for the standalone SSE stream, whose 401 handler re-enters authorization and reopens the
+   * stream with no circuit breaker and no backoff - measured at several hundred exchanges a second,
+   * indefinitely, which is what gets people rate-limited by their own identity provider.
+   *
+   * Every one of those exchanges ends here, so this is the one place the loop can be seen from and
+   * the one place it can be stopped. Throwing fails the authorization that asked for the write,
+   * which is what unwinds the stream's retry.
+   *
+   * The window is a sliding one, so a client that stops hammering is trusted again shortly after.
+   */
+  private inTokenStorm(): boolean {
+    const now = Date.now()
+    this.recentTokenWrites = this.recentTokenWrites.filter((at) => now - at < TOKEN_STORM_WINDOW_MS)
+    return this.recentTokenWrites.length >= TOKEN_STORM_LIMIT
+  }
+
+  /** The error both halves of the brake raise, so the cause reads the same wherever it surfaces. */
+  private tokenStormError(): Error {
+    const seconds = TOKEN_STORM_WINDOW_MS / 1000
+    log(
+      `Stopping: ${TOKEN_STORM_LIMIT} access tokens were issued in the last ${seconds}s and the MCP server ` +
+        `rejected them all. Asking for another would only repeat the exchange.`,
+    )
+    debugLog('Token exchange loop detected', { writes: this.recentTokenWrites.length, windowMs: TOKEN_STORM_WINDOW_MS })
+    return new Error(
+      `Stopped after ${TOKEN_STORM_LIMIT} token exchanges in ${seconds}s. The tokens being issued are not accepted ` +
+        `by the MCP server - check that its audience and scopes match, or sign in again.`,
+    )
+  }
+
+  private guardAgainstTokenStorm(): void {
+    if (this.inTokenStorm()) throw this.tokenStormError()
+    this.recentTokenWrites.push(Date.now())
+  }
+
   async saveTokens(tokens: OAuthTokens): Promise<void> {
+    this.guardAgainstTokenStorm()
+
     const timeLeft = tokens.expires_in || 0
 
     // Alert if expires_in is invalid
@@ -413,6 +469,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    * @param authorizationUrl The URL to redirect to
    */
   async redirectToAuthorization(authorizationUrl: URL): Promise<void> {
+    // A refused refresh sends the SDK down the full authorization path, so without this the brake
+    // would turn an exchange loop into a browser-tab loop - the same storm, more visible.
+    if (this.inTokenStorm()) throw this.tokenStormError()
+
     // Optionally fetch metadata for debugging/informational purposes (non-blocking)
     this.getAuthorizationServerMetadata().catch(() => {
       // Ignore errors, metadata is optional


### PR DESCRIPTION
Relates to #91, #68, #149.

Found while investigating the runtime re-auth cluster. It is not what any of those issues describe, and it is worse than all of them.

### The loop

When an authorization server keeps honouring a refresh token while the MCP server keeps rejecting the access tokens it returns — tokens revoked server-side, an audience mismatch, a resource the token was not issued for — the SDK's standalone SSE stream spins:

```
_startOrAuthSse → GET /mcp → 401 → _authThenStart → auth() → refresh → _startOrAuthSse → …
```

The SDK has a circuit breaker for exactly this. `_hasCompletedAuthFlow` is even commented *"detect auth success followed by immediate 401"*. But it is only consulted on the POST path (`streamableHttp.js:316`). The GET path has no guard and no backoff, so it recurses as fast as the network allows.

Measured against a local authorization server, with tokens revoked server-side after a successful sign-in:

```
t+5s    2784 token requests
t+30s  13750 token requests        ~456/s, still climbing linearly
       challenge_GET: 530  vs  challenge_POST: 3   (the POST breaker works)
       4 browser tabs opened in 30s
       2262 writes to tokens.json
```

It never terminates. Against a real identity provider this is an immediate 429, which is what @Sudhishna reported on #91, and it explains the "floods of re-auths" on #68 and #149 far better than anything about instance coordination.

### The brake

Every one of those exchanges ends at `saveTokens`, so that is the one place this is visible from and the one place it can be stopped. More than 20 tokens persisted inside a 30 second window is not a cadence any token lifetime can produce, so the next exchange is refused.

`redirectToAuthorization` refuses too while the brake is on. Without that, a refused refresh just sends the SDK down the full authorization path instead and the storm comes back as browser tabs — same storm, more visible. The window slides, so a client that stops hammering is trusted again ~30s later rather than being broken until restart.

### Effect

| | before | after |
| --- | --- | --- |
| token exchanges | 13,750 in 30s, unbounded | 23, then stops |
| sustained rate | ~456/s | stops after 2.6s |
| browser tabs at runtime | 4 | 0 |
| authorize round-trips | 5 | 1 |

A healthy flow is untouched — same harness, server accepting tokens normally: `tools/call` succeeds, 1 token issued, 1 tab, 1 authorize. The 8 concurrent-instance scenarios still pass unchanged.

### Scope

This is a mitigation, not the cure. The cure is the missing guard in `_authThenStart` upstream; users are pinned to whatever SDK version ships, so the brake is what actually protects them today. It sits at the token-persistence choke point, so it covers any path that reaches it, not just this one.

It does **not** fix the runtime re-auth cluster itself (#248, #133, #286, #179, #256) — a mid-session 401 still cannot complete a sign-in. That is separate work.
