### PR TITLE
fix: stop discarding stored sign-ins on every release

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -15,7 +15,7 @@
 - **Main Binaries**: `mcp-remote` (proxy.ts), `mcp-remote-client` (client.ts)
 - **Core Libraries**: `/src/lib/` contains auth coordination, OAuth client, utils, types
 - **Transport**: Supports both HTTP and SSE transports with OAuth authentication
-- **Config**: Credentials live in `~/.mcp-auth/mcp-remote-{version}/`, keyed by a hash of the server URL. `MCP_REMOTE_CONFIG_DIR` overrides the base directory, not the version subdirectory
+- **Config**: Credentials live in `~/.mcp-auth/mcp-remote-v{store}/`, keyed by a hash of the server URL. The subdirectory names the _store layout_, not the package version, so releases do not discard anyone's sign-ins - raise `CONFIG_STORE_VERSION` only when something already on disk would be misread. `MCP_REMOTE_CONFIG_DIR` relocates the base directory
 
 ## Code Style
 

--- a/README.md
+++ b/README.md
@@ -380,6 +380,11 @@ rm -rf ~/.mcp-auth
 
 Then restarting your MCP client.
 
+Credentials are stored under `mcp-remote-v1`, which names the layout of the store rather than the
+version of the package, so upgrading `mcp-remote` no longer signs you out. Releases before this
+change kept a separate directory per version — if you have `~/.mcp-auth/mcp-remote-0.x.y`
+directories left over, they hold old tokens and can be deleted.
+
 ### Check your Node version
 
 Make sure that the version of Node you have installed is [18 or

--- a/src/lib/mcp-auth-config.test.ts
+++ b/src/lib/mcp-auth-config.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { writeJsonFile, readJsonFile, getConfigFilePath, deleteStaleConfigFiles } from './mcp-auth-config'
+import { writeJsonFile, readJsonFile, getConfigFilePath, deleteStaleConfigFiles, getConfigDir } from './mcp-auth-config'
 
 vi.mock('./utils', () => ({
   log: vi.fn(),
@@ -21,6 +21,35 @@ beforeEach(async () => {
 afterEach(async () => {
   delete process.env.MCP_REMOTE_CONFIG_DIR
   await fs.rm(configDir, { recursive: true, force: true })
+})
+
+describe('Feature: Where credentials are stored', () => {
+  const configDirEnv = process.env.MCP_REMOTE_CONFIG_DIR
+
+  afterEach(() => {
+    if (configDirEnv === undefined) delete process.env.MCP_REMOTE_CONFIG_DIR
+    else process.env.MCP_REMOTE_CONFIG_DIR = configDirEnv
+  })
+
+  it('Scenario: The path does not move when the package version does', () => {
+    // Given the package version the rest of the code reports
+    delete process.env.MCP_REMOTE_CONFIG_DIR
+    const before = getConfigDir()
+
+    // When a release ships - the mocked version above stands in for it
+    // Then the credentials are still looked for in the same place, so nobody has to sign in again
+    expect(before).not.toContain('1.0.0')
+    expect(before).toBe(path.join(os.homedir(), '.mcp-auth', 'mcp-remote-v1'))
+  })
+
+  it('Scenario: MCP_REMOTE_CONFIG_DIR relocates the store and keeps it stable', () => {
+    // The documented workaround for this used to relocate the base and then append the package
+    // version underneath it anyway, so it never actually stopped the re-authentication
+    process.env.MCP_REMOTE_CONFIG_DIR = '/tmp/somewhere-else'
+
+    expect(getConfigDir()).toBe(path.join('/tmp/somewhere-else', 'mcp-remote-v1'))
+    expect(getConfigDir()).not.toContain('1.0.0')
+  })
 })
 
 describe('Feature: Config file writes', () => {

--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -1,7 +1,7 @@
 import path from 'path'
 import os from 'os'
 import fs from 'fs/promises'
-import { log, debugLog, MCP_REMOTE_VERSION } from './utils'
+import { log, debugLog } from './utils'
 
 /**
  * MCP Remote Authentication Configuration
@@ -9,7 +9,8 @@ import { log, debugLog, MCP_REMOTE_VERSION } from './utils'
  * This module handles the storage and retrieval of authentication-related data for MCP Remote.
  *
  * Configuration directory structure:
- * - The config directory is determined by MCP_REMOTE_CONFIG_DIR env var or defaults to ~/.mcp-auth
+ * - The config directory is determined by MCP_REMOTE_CONFIG_DIR env var or defaults to ~/.mcp-auth,
+ *   with a subdirectory naming the store layout - stable across releases, see CONFIG_STORE_VERSION
  * - Each file is prefixed with a hash of the server URL to separate configurations for different servers
  *
  * Files stored in the config directory:
@@ -27,13 +28,27 @@ import { log, debugLog, MCP_REMOTE_VERSION } from './utils'
  */
 
 /**
+ * The layout of the stored credentials, not the version of this package.
+ *
+ * Raise it by hand, and only when something already on disk would be misread by the code reading
+ * it - a renamed file, a changed shape, a credential that has to be reissued. Everyone's stored
+ * sign-ins are discarded when it changes, so that is the whole point of it and also the reason it
+ * should almost never move.
+ *
+ * It used to be the package version, which meant every release discarded them: a token store is
+ * keyed by this directory, so a new version always found an empty one and every server asked the
+ * user to sign in again. At ten releases in three days, that was a sign-in per release per server
+ * (see https://github.com/geelen/mcp-remote/issues/200).
+ */
+const CONFIG_STORE_VERSION = 1
+
+/**
  * Gets the configuration directory path
  * @returns The path to the configuration directory
  */
 export function getConfigDir(): string {
   const baseConfigDir = process.env.MCP_REMOTE_CONFIG_DIR || path.join(os.homedir(), '.mcp-auth')
-  // Add a version subdirectory so we don't need to worry about backwards/forwards compatibility yet
-  return path.join(baseConfigDir, `mcp-remote-${MCP_REMOTE_VERSION}`)
+  return path.join(baseConfigDir, `mcp-remote-v${CONFIG_STORE_VERSION}`)
 }
 
 /**

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -10,6 +10,7 @@ import {
   parseSecondsOption,
   MCP_REMOTE_VERSION,
 } from './utils'
+import { getConfigDir } from './mcp-auth-config'
 import { Headers as UndiciHeaders } from 'undici'
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { StreamableHTTPError } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
@@ -1984,7 +1985,8 @@ describe('Feature: Stale Client Registration Invalidation', () => {
   beforeEach(() => {
     baseDir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-remote-test-'))
     process.env.MCP_REMOTE_CONFIG_DIR = baseDir
-    versionDir = path.join(baseDir, `mcp-remote-${MCP_REMOTE_VERSION}`)
+    // Asked for rather than rebuilt here, so the store layout can be renamed without these lying
+    versionDir = getConfigDir()
   })
 
   afterEach(() => {


### PR DESCRIPTION
Fixes #200.

The credential store was keyed by the package version:

```ts
return path.join(baseConfigDir, `mcp-remote-${MCP_REMOTE_VERSION}`)
```

A new version therefore always found an empty store, and every OAuth server asked the user to sign in again. That is a sign-in per release, per server, for anyone running `npx mcp-remote` without a version pin — which is how the README tells people to run it.

It has been latent for a long time and became acute this week: **ten releases since Aug 24**, four of them on Aug 26. Anyone unpinned re-authenticated four times in one day.

```
v0.3.1  Aug 26 19:05
v0.3.0  Aug 26 17:56
v0.2.7  Aug 26 17:42
v0.2.6  Aug 26 16:25
v0.2.5  Aug 26 03:22
v0.2.4  Aug 25 19:01
...
```

### The documented workaround did not work either

#200 and various threads suggest setting `MCP_REMOTE_CONFIG_DIR`. That only relocated the *base*; the per-version subdirectory was still appended underneath it:

```
MCP_REMOTE_CONFIG_DIR=/tmp/custom  ->  /tmp/custom/mcp-remote-0.3.1
next release                       ->  /tmp/custom/mcp-remote-0.3.2   <- still empty
```

So people who followed that advice kept re-authenticating anyway.

### The fix

The subdirectory now names the **store layout** instead of the package version:

```ts
const CONFIG_STORE_VERSION = 1
return path.join(baseConfigDir, `mcp-remote-v${CONFIG_STORE_VERSION}`)
```

This keeps the ability @geelen asked for on #200 — *"I really want the ability to blow the auth cache if we need to make a backwards-incompatible change"* — without exercising it on every release. Raising `CONFIG_STORE_VERSION` discards everyone's stored sign-ins, which is exactly what it is for and why it should almost never move. The package version was only ever a proxy for "the format might have changed", and a bad one: it fired on docs-only releases too.

No migration, so everyone signs in once more on upgrade and then stops. Old `mcp-remote-0.x.y` directories are left alone; they still contain tokens, and the README now says they can be deleted.

### Verification

Two scenarios, both failing against the old path and passing here — one that the path does not move with the package version, one that `MCP_REMOTE_CONFIG_DIR` relocates the store *and* keeps it stable.

The stale-registration tests in `utils.test.ts` had rebuilt this directory name by hand and broke when it changed; they now ask `getConfigDir()` for it, so they cannot drift again.

README and AGENT.md updated.
