### PR TITLE
fix: complete a sign-in the server asks for mid-session

### DIFF
--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -1824,6 +1824,45 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
     expect(defaultPath.status).toBe(404)
   })
 
+  it('hands each sign-in its own code, so a used one is never replayed', async () => {
+    const result = await setupOAuthCallbackServerWithLongPoll({ port: 0, path: '/oauth/callback', events, serverUrlHash: 'h' })
+    server = result.server
+    const base = `http://127.0.0.1:${result.actualPort}/oauth/callback`
+
+    // Given a first sign-in, redeemed by whoever asked for it
+    await fetch(`${base}?code=first&state=s1`)
+    expect(await result.waitForAuthCode()).toEqual({ code: 'first', state: 's1' })
+
+    // When the user signs in again later, because the tokens were revoked
+    await fetch(`${base}?code=second&state=s2`)
+
+    // Then the second code is handed over. Returning `first` again would be replaying a
+    // single-use code, which the authorization server refuses with invalid_grant.
+    expect(await result.waitForAuthCode()).toEqual({ code: 'second', state: 's2' })
+  })
+
+  it('holds a code that arrives before anyone is waiting for it', async () => {
+    const result = await setupOAuthCallbackServerWithLongPoll({ port: 0, path: '/oauth/callback', events, serverUrlHash: 'h' })
+    server = result.server
+
+    // The browser reaches the callback before the flow gets round to asking; both orders happen
+    await fetch(`http://127.0.0.1:${result.actualPort}/oauth/callback?code=early`)
+
+    expect(await result.waitForAuthCode()).toEqual({ code: 'early', state: undefined })
+  })
+
+  it('still tells a sibling the sign-in finished after the code has been taken', async () => {
+    const result = await setupOAuthCallbackServerWithLongPoll({ port: 0, path: '/oauth/callback', events, serverUrlHash: 'h' })
+    server = result.server
+
+    await fetch(`http://127.0.0.1:${result.actualPort}/oauth/callback?code=taken`)
+    await result.waitForAuthCode()
+
+    // Draining the queue must not make "has the user finished?" go back to no
+    const poll = await fetch(`http://127.0.0.1:${result.actualPort}/wait-for-auth?poll=false`)
+    expect(poll.status).toBe(200)
+  })
+
   it('should reject with EADDRINUSE error when strictPort is true and port is already in use', async () => {
     const blocker = net.createServer()
     const blockedPort = await new Promise<number>((resolve) => {
@@ -1928,6 +1967,91 @@ describe('Feature: Network Tuning Options', () => {
 
     // Then they are consumed as options rather than mistaken for the URL or the callback port
     expect(result.serverUrl).toBe('https://example.remote/server')
+  })
+})
+
+describe('Feature: Completing a sign-in the server asked for mid-session', () => {
+  const mockTransport = () =>
+    ({
+      send: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      onmessage: vi.fn(),
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+    }) as unknown as Transport
+
+  /** A server transport that refuses the first `refusals` sends as unauthorized. */
+  const refusingTransport = (refusals: number) => {
+    const transport = mockTransport()
+    let refused = 0
+    ;(transport.send as any).mockImplementation(async () => {
+      if (refused++ < refusals) throw new Error('Error POSTing to endpoint (HTTP 401): Unauthorized')
+    })
+    return transport
+  }
+
+  it('Scenario: A refused request is retried once the sign-in completes', async () => {
+    // Given a server that refuses until somebody signs in
+    const client = mockTransport()
+    const server = refusingTransport(1)
+    const reauthorize = vi.fn().mockResolvedValue(undefined)
+    mcpProxy({ transportToClient: client, transportToServer: server, reauthorize })
+
+    // When a request is refused
+    client.onmessage!({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'x' } } as any)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    // Then the sign-in runs and the request is delivered, rather than answered with an error
+    expect(reauthorize).toHaveBeenCalledTimes(1)
+    expect(server.send).toHaveBeenCalledTimes(2)
+    expect(client.send).not.toHaveBeenCalled()
+  })
+
+  it('Scenario: Requests refused together share one sign-in', async () => {
+    const client = mockTransport()
+    const server = refusingTransport(3)
+    let signIns = 0
+    const reauthorize = vi.fn().mockImplementation(async () => {
+      signIns++
+      await new Promise((resolve) => setTimeout(resolve, 10))
+    })
+    mcpProxy({ transportToClient: client, transportToServer: server, reauthorize })
+
+    // When three requests are refused at once
+    for (const id of [1, 2, 3]) {
+      client.onmessage!({ jsonrpc: '2.0', id, method: 'tools/call', params: { name: 'x' } } as any)
+    }
+    await new Promise((resolve) => setTimeout(resolve, 60))
+
+    // Then the user is asked to sign in once, not three times
+    expect(signIns).toBe(1)
+  })
+
+  it('Scenario: Still refused after signing in, the client is told', async () => {
+    // Given a server that refuses even the token just obtained
+    const client = mockTransport()
+    const server = refusingTransport(Number.MAX_SAFE_INTEGER)
+    const reauthorize = vi.fn().mockResolvedValue(undefined)
+    mcpProxy({ transportToClient: client, transportToServer: server, reauthorize })
+
+    client.onmessage!({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'x' } } as any)
+    await new Promise((resolve) => setTimeout(resolve, 30))
+
+    // Then it stops after one attempt and answers, rather than signing in forever
+    expect(reauthorize).toHaveBeenCalledTimes(1)
+    expect(client.send).toHaveBeenCalledWith(expect.objectContaining({ id: 1, error: expect.anything() }))
+  })
+
+  it('Scenario: Without a way to sign in, the refusal is answered as before', async () => {
+    const client = mockTransport()
+    const server = refusingTransport(1)
+    mcpProxy({ transportToClient: client, transportToServer: server })
+
+    client.onmessage!({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'x' } } as any)
+    await new Promise((resolve) => setTimeout(resolve, 20))
+
+    expect(client.send).toHaveBeenCalledWith(expect.objectContaining({ id: 1, error: expect.anything() }))
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -171,10 +171,19 @@ export function mcpProxy({
   transportToClient,
   transportToServer,
   ignoredTools = [],
+  reauthorize,
 }: {
   transportToClient: Transport
   transportToServer: Transport
   ignoredTools?: string[]
+  /**
+   * Completes a sign-in for a request the server refused, or undefined to answer with the error.
+   *
+   * Supplied by the caller rather than built here, because finishing a flow needs the auth
+   * provider and the callback server, neither of which a proxy between two transports should know
+   * about.
+   */
+  reauthorize?: () => Promise<void>
 }) {
   let transportToClientClosed = false
   let transportToServerClosed = false
@@ -183,6 +192,7 @@ export function mcpProxy({
   let reinitSeq = 0
   const pendingReinit = new Map<string, (message: Message) => void>()
   let initializedDelivered: Promise<unknown> | null = null
+  let reauthorizeInFlight: Promise<void> | null = null
 
   const messageTransformer = createMessageTransformer({
     transformRequestFunction: (request: Message) => {
@@ -429,11 +439,49 @@ export function mcpProxy({
     void sendToServer(message)
   }
 
-  async function sendToServer(message: Message) {
+  /**
+   * Whether the server refused this because nobody is signed in.
+   *
+   * The SDK has already opened a browser by the time this surfaces: its transport answers a 401 by
+   * running `auth()`, which reaches `redirectToAuthorization` and then throws because the flow has
+   * not finished. So the user is looking at a consent screen whose redirect is on its way to the
+   * callback port - all that is missing is somebody to receive the code and redeem it.
+   */
+  function isUnauthorized(error: Error) {
+    return error instanceof UnauthorizedError || error.message.includes('Unauthorized')
+  }
+
+  /** Coalesces concurrent callers, so several refused requests produce one sign-in, not one each */
+  function reauthorizeOnce(): Promise<void> {
+    if (!reauthorizeInFlight) {
+      reauthorizeInFlight = reauthorize!().finally(() => {
+        reauthorizeInFlight = null
+      })
+    }
+    return reauthorizeInFlight
+  }
+
+  async function sendToServer(message: Message, alreadyReauthorized = false) {
     try {
       await transportToServer.send(message)
       return
     } catch (error) {
+      // The sign-in the SDK started can still be completed, but only by someone holding the
+      // callback port. Retried once: a second refusal is the server rejecting a token we just
+      // obtained, which another flow will not fix (see issues #133, #179, #248, #256, #286).
+      if (reauthorize && !alreadyReauthorized && isUnauthorized(error as Error)) {
+        log('Remote server requires authorization, completing sign-in')
+        debugLog('Unauthorized send, re-authorizing', { id: message.id, method: message.method })
+        try {
+          await reauthorizeOnce()
+          await sendToServer(message, true)
+        } catch (authError) {
+          onServerError(authError as Error)
+          replyWithError(message, authError as Error)
+        }
+        return
+      }
+
       // Re-initializing in response to a failed initialize would loop
       if (!isSessionExpired(error as Error) || message.method === 'initialize') {
         onServerError(error as Error)
@@ -877,7 +925,28 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   waitForAuthCode: () => Promise<AuthCodeResult>
   authCompletedPromise: Promise<AuthCodeResult>
 }> {
-  let authCode: AuthCodeResult | null = null
+  /**
+   * Codes that have arrived and nobody has redeemed yet, oldest first.
+   *
+   * A queue rather than one retained code, because a process signs in more than once: tokens are
+   * revoked, refresh tokens lapse, a server starts asking for a scope it did not before. The old
+   * single slot handed every later caller the *first* code it ever saw, and an authorization code
+   * is single-use (RFC 6749 4.1.2), so redeeming it a second time fails with `invalid_grant`.
+   */
+  const unclaimedCodes: AuthCodeResult[] = []
+
+  /** Callers waiting for a code that has not arrived yet, in the order they asked. */
+  const waitingForCode: Array<{ resolve: (result: AuthCodeResult) => void; reject: (error: Error) => void }> = []
+
+  /**
+   * Whether any sign-in has ever completed here.
+   *
+   * Kept separate from the queue: a sibling polling the long-poll endpoint is asking "has the
+   * user finished, so are there tokens on disk for me to read", which stays true once it is true.
+   * Draining the queue must not make that answer go backwards.
+   */
+  let authEverCompleted = false
+
   const app = express()
 
   // Create a promise to track when auth is completed
@@ -888,7 +957,7 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
 
   // Long-polling endpoint
   app.get(LONG_POLL_PATH, (req, res) => {
-    if (authCode) {
+    if (authEverCompleted) {
       // Auth already completed - just return 200 without the actual code
       // Secondary instances will read tokens from disk
       log('Auth already completed, returning 200')
@@ -949,9 +1018,16 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
       return
     }
 
-    authCode = { code, state }
+    const received: AuthCodeResult = { code, state }
+    authEverCompleted = true
     log('Auth code received, resolving promise')
-    authCompletedResolve(authCode)
+    authCompletedResolve(received)
+
+    // Hand it straight to whoever is waiting; hold it only if nobody is yet. The startup flow
+    // reaches `waitForAuthCode` after the browser has already been sent here, so both orders happen.
+    const waiter = waitingForCode.shift()
+    if (waiter) waiter.resolve(received)
+    else unclaimedCodes.push(received)
 
     res.send(`
       Authorization successful!
@@ -992,29 +1068,32 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
     })
   })
 
+  /** Takes the next unredeemed code, waiting for one if none has arrived. */
   const waitForAuthCode = (): Promise<AuthCodeResult> => {
-    return new Promise((resolve, reject) => {
-      if (authCode) {
-        resolve(authCode)
-        return
-      }
+    const alreadyHere = unclaimedCodes.shift()
+    if (alreadyHere) return Promise.resolve(alreadyHere)
 
+    return new Promise((resolve, reject) => {
+      const entry = {
+        resolve,
+        // An authorization the user denied never produces a code, and waiting for one holds the
+        // callback port for the life of the process
+        reject: (error: Error) => {
+          options.events.off('auth-code-failed', onFailure)
+          reject(error)
+        },
+      }
       const onFailure = (error: Error) => {
-        options.events.off('auth-code-received', onCode)
-        reject(error)
+        const index = waitingForCode.indexOf(entry)
+        if (index !== -1) waitingForCode.splice(index, 1)
+        entry.reject(error)
       }
-      const onCode = (code: string, state?: string) => {
-        options.events.off('auth-code-failed', onFailure)
-        resolve({ code, state })
-      }
-      options.events.once('auth-code-received', onCode)
-      // An authorization the user denied never produces a code, and waiting for one holds the
-      // callback port for the life of the process
+      waitingForCode.push(entry)
       options.events.once('auth-code-failed', onFailure)
     })
   }
 
-  return { server, actualPort, authCode, waitForAuthCode, authCompletedPromise }
+  return { server, actualPort, authCode: null, waitForAuthCode, authCompletedPromise }
 }
 
 /**

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -11,6 +11,7 @@
 
 import { EventEmitter } from 'events'
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js'
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js'
 import {
   connectToRemoteServer,
   log,
@@ -24,6 +25,12 @@ import {
 import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
 import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
 import { createLazyAuthCoordinator, hasUsableTokens, serverIssuesAuthChallenge } from './lib/coordination'
+
+/** A transport that can redeem an authorization code, which the `Transport` interface does not promise. */
+type AuthCompletable = Transport & { finishAuth: (code: string) => Promise<void> }
+
+const canFinishAuth = (transport: Transport): transport is AuthCompletable =>
+  typeof (transport as Partial<AuthCompletable>).finishAuth === 'function'
 
 /**
  * Main function to run the proxy
@@ -131,6 +138,35 @@ async function runProxy(
       transportToClient: localTransport,
       transportToServer: remoteTransport,
       ignoredTools,
+      /**
+       * Finishes a sign-in the remote server asked for mid-session.
+       *
+       * Startup is not the only time a server can demand one: tokens get revoked, refresh tokens
+       * lapse, and a server may leave `initialize` public while protecting a tool. Until now those
+       * all ended the same way - the SDK opened a browser, nothing was listening on the callback
+       * port, and the code was dropped on the floor.
+       */
+      reauthorize: async () => {
+        const { waitForAuthCode, skipBrowserAuth } = await authInitializer()
+
+        // Another instance is running the flow; it will write the tokens and the retry will pick
+        // them up. Waiting for a code of our own here would wait for one nobody will deliver.
+        if (skipBrowserAuth) {
+          log('Another instance is completing the sign-in; retrying with the tokens it writes')
+          return
+        }
+
+        const { code, state } = await waitForAuthCode()
+        // The code may belong to a flow another instance started, whose verifier is not this one's
+        if (state) authProvider.useAuthorizationState(state)
+
+        // Both transports this proxy can be given have it; the interface they share does not
+        if (!canFinishAuth(remoteTransport)) {
+          throw new Error(`${remoteTransport.constructor.name} cannot complete an authorization`)
+        }
+        await remoteTransport.finishAuth(code)
+        log('Re-authorized with the remote server')
+      },
     })
 
     // Start the local STDIO server


### PR DESCRIPTION
Fixes #248. Fixes #133. Fixes #286. Fixes #179. Fixes #256.

Design and approach from @jacopoc's #321 — the coalesced `authInitializer() → waitForAuthCode() → finishAuth()` flow is theirs. This rebuilds it on current `main` and fixes one defect, described below. #321 can be closed as superseded.

### The problem

A 401 mid-session was the end of the road. The SDK's transport answers one by running `auth()`, which opens a browser and then throws because the flow has not finished — and `mcpProxy` only logged that error and replied to the client. Nothing was listening on the callback port, so the code the user worked for was dropped.

Reproduced on 0.3.2 against a local authorization server, with a server that leaves `initialize` public and protects one tool:

```
tools/call    -32001: mcp-remote: Unauthorized
tabs opened   1     redirect_uri http://localhost:31225/oauth/callback
listener?     false
POST /token   0
```

A client registration and a full authorize round-trip, burned for nothing.

### The fix

- **The callback server hands out codes as a queue.** A process signs in more than once — tokens get revoked, refresh tokens lapse — and the old single retained code handed every later caller the *first* one it ever saw. `authEverCompleted` is tracked separately so draining the queue does not make the sibling long-poll signal go backwards.
- **`mcpProxy` takes a `reauthorize` callback.** `sendToServer` now treats `UnauthorizedError` the way it already treats an expired session: coalesce concurrent callers into one sign-in, retry the message once, answer with a JSON-RPC error if it is still refused. Bounded deliberately — a second refusal means the server is rejecting a token just issued, which another flow will not fix.
- **`proxy.ts` supplies it**, because finishing a flow needs the auth provider and the callback server, neither of which a proxy between two transports should know about. It also calls `useAuthorizationState(state)`, so a code belonging to a sibling's flow is redeemed with that flow's verifier.

### Why the queue, and not a reset

#321 handles the retained code by nulling it on a `reset-auth-code` event. That leaves a race, and losing it replays a single-use code. Measured here against a server that enforces RFC 6749 §4.1.2:

| | retained code | queue |
| --- | --- | --- |
| `tools/call` | `-32001: authorization code already used` | succeeds |
| codes replayed | 2 | 0 |
| authorize round-trips | 6 | 2 |
| tool calls served | 0 | 1 |

### Validation

| scenario | before | after |
| --- | --- | --- |
| public until `tools/call` (#133, #286) | `-32001`, no listener, 0 exchanges | call succeeds, 1 exchange, 1 tab |
| both tokens revoked mid-session (#248, #256) | `-32001`, 13,750 exchanges, 4 tabs | call succeeds, 3 exchanges, 1 tab |

Note on the second row: it only exercises this code once the test server rejects *refresh* tokens as well. With a live refresh token the SDK recovers on its own and never reaches here — worth knowing when testing this by hand, because it looks like a pass either way.

Seven tests, each confirmed to fail against the previous behaviour: retry after sign-in, concurrent requests sharing one sign-in, bounded retry, unchanged behaviour when no `reauthorize` is supplied, and three on the queue (distinct codes per sign-in, a code arriving before anyone waits, the sibling signal surviving a drained queue).

232 unit tests and the 8 concurrent-instance scenarios all pass, so the sign-in coordination is undisturbed.

### Not covered

#91's infinite-loop half was fixed in #338; what remains of it should be resolved by this, but it needs the reporter to confirm. #181 asks for the same flow plus refresh-token reuse, most of which landed earlier in the proactive refresh.
