### PR TITLE
fix: sign in again when the scopes this client asks for change

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -190,6 +190,63 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
     })
   })
 
+  describe('a changed scope request', () => {
+    const storedWith = (requested_scope: string | undefined) => {
+      mockReadJsonFile.mockResolvedValue({
+        access_token: 'at',
+        refresh_token: 'rt',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        ...(requested_scope === undefined ? {} : { requested_scope }),
+      })
+    }
+
+    it('signs in again when a scope is added to the configuration', async () => {
+      // Given a token obtained when only read access was configured
+      provider = new NodeOAuthClientProvider({ ...defaultOptions, staticOAuthClientMetadata: { scope: 'a.read a.write' } as any })
+      storedWith('a.read')
+
+      // Then it is discarded, so the next flow asks for both
+      await expect(provider.tokens()).resolves.toBeUndefined()
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', 'tokens.json')
+    })
+
+    it('keeps a token the server granted less scope than we asked for', async () => {
+      // Given a server that granted a subset, which RFC 6749 3.3 permits
+      provider = new NodeOAuthClientProvider({ ...defaultOptions, staticOAuthClientMetadata: { scope: 'a.read a.write' } as any })
+      mockReadJsonFile.mockResolvedValue({
+        access_token: 'at',
+        refresh_token: 'rt',
+        token_type: 'Bearer',
+        expires_in: 3600,
+        scope: 'a.read',
+        requested_scope: 'a.read a.write',
+      })
+
+      // Then nothing is discarded. Signing in again would return the same narrower grant, so
+      // treating it as a reason to retry is a loop with nothing to end it.
+      await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'at' })
+      expect(mockDeleteConfigFile).not.toHaveBeenCalled()
+    })
+
+    it('reuses a token when the configuration has not changed', async () => {
+      provider = new NodeOAuthClientProvider({ ...defaultOptions, staticOAuthClientMetadata: { scope: 'a.read' } as any })
+      storedWith('a.read')
+
+      await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'at' })
+      expect(mockDeleteConfigFile).not.toHaveBeenCalled()
+    })
+
+    it('leaves a token stored before this was recorded alone', async () => {
+      // Nobody should be signed out by upgrading
+      provider = new NodeOAuthClientProvider({ ...defaultOptions, staticOAuthClientMetadata: { scope: 'a.read' } as any })
+      storedWith(undefined)
+
+      await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'at' })
+      expect(mockDeleteConfigFile).not.toHaveBeenCalled()
+    })
+  })
+
   describe('token exchange loop protection', () => {
     const anAccessToken = { access_token: 'at', token_type: 'Bearer', expires_in: 3600 } as any
 

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -26,6 +26,8 @@ import { getAuthorizationServerUrl, type ProtectedResourceMetadata } from './pro
  */
 export const OAuthTokensWithExpiresAtSchema = OAuthTokensSchema.extend({
   expires_at: z.coerce.number().optional(),
+  /** The scope this client asked for when the token was obtained. See {@link scopeRequestChanged}. */
+  requested_scope: z.string().optional(),
 })
 type OAuthTokensWithExpiresAt = z.infer<typeof OAuthTokensWithExpiresAtSchema>
 
@@ -270,6 +272,16 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
 
     const tokens = await readJsonFile<OAuthTokensWithExpiresAt>(this.serverUrlHash, 'tokens.json', OAuthTokensWithExpiresAtSchema)
 
+    if (tokens && this.scopeRequestChanged(tokens)) {
+      log('The scopes this client asks for have changed since it signed in; signing in again')
+      debugLog('Discarding a token obtained for a different scope request', {
+        obtainedFor: tokens.requested_scope,
+        nowRequesting: this.getEffectiveScope(),
+      })
+      await this.invalidateCredentials('tokens')
+      return undefined
+    }
+
     if (tokens) {
       const timeLeft = tokens.expires_in || 0
 
@@ -313,6 +325,26 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
 
     return tokens
+  }
+
+  /**
+   * Whether this run is asking for something different from what the stored token was obtained for.
+   *
+   * Compares request against request, deliberately, not against what the server granted. An
+   * authorization server may grant *less* than it was asked for (RFC 6749 3.3), and treating that
+   * as a reason to sign in again is a loop with nothing to break it: the next sign-in returns the
+   * same narrower grant, which is rejected the same way. Comparing the two requests only fires
+   * when the configuration actually changed - a scope added to `--static-oauth-client-metadata`,
+   * say - and then only once, because the new token records the new request.
+   *
+   * A token stored before this was recorded has no request to compare, and is left alone.
+   *
+   * @param tokens The tokens read from disk
+   * @returns True if a fresh authorization is needed to cover what is being asked for now
+   */
+  private scopeRequestChanged(tokens: OAuthTokensWithExpiresAt): boolean {
+    if (tokens.requested_scope === undefined) return false
+    return tokens.requested_scope !== this.getEffectiveScope()
   }
 
   /**
@@ -455,6 +487,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     const tokensToSave: OAuthTokensWithExpiresAt = {
       ...tokens,
       expires_at: tokens.expires_in ? Date.now() + tokens.expires_in * 1000 : undefined,
+      requested_scope: this.getEffectiveScope(),
     }
 
     await writeJsonFile(this.serverUrlHash, 'tokens.json', tokensToSave)


### PR DESCRIPTION
Supersedes #313 — the idea and the motivating case are @ringomax's.

A connection can be configured to ask for one scope and later for more. The stored token still satisfies the old request, so it gets reused and every call fails on a permission the user thought they had granted.

### Why not compare against what was granted

#313 compares the token's **granted** scope against what is requested now, and discards the token if the grant does not cover it. That loops: an authorization server may grant less than it was asked for (RFC 6749 §3.3), so the next sign-in returns the same narrower grant and is discarded again, forever. Same shape as the storm fixed in #338.

Tested against #313's rule:

| stored | requested | #313 | why it matters |
| --- | --- | --- | --- |
| `openid email` | `openid email profile` | **delete** | server granted a subset — legal, loops |
| `mcp` | `openid email profile` | **delete** | our fallback default vs the server's own scope — loops |
| *(no `scope` recorded)* | anything | **delete** | every token stored by an older version — signs out every user on upgrade |

Three of the four scenarios here fail under that rule.

### What this does instead

Records the scope that was **requested** when the token was obtained, and compares request against request. It fires only when the configuration actually changed, and only once, because the new token records the new request. A server granting less never triggers it, and a token stored before this was recorded has nothing to compare and is left alone.

### Tests

Four scenarios: a scope added to the configuration signs in again; a narrower grant does not; an unchanged configuration reuses the token; a token stored before this change is untouched.
