### PR TITLE
feat: read custom headers from a file with --header-file

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,25 @@ To bypass authentication, or to emit custom headers on all requests to your remo
 },
 ```
 
+To keep a credential out of the process arguments — where any other user on the machine can read it from the process list — put the headers in a file instead and pass `--header-file`. One `Name: value` per line; `#` starts a comment.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--header-file",
+        "/path/to/headers.txt"
+      ]
+```
+
+```
+# credentials for the example server
+Authorization: Bearer my-token
+X-Custom-Header: custom-value
+```
+
+A file that cannot be read is an error rather than a warning, so a mistyped path fails immediately instead of sending the request unauthenticated.
+
 ### Multiple Instances
 
 To run multiple instances of the same remote server with different configurations (e.g., different Atlassian tenants), use the `--resource` flag to isolate OAuth sessions:

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -198,6 +198,57 @@ describe('Feature: Command Line Arguments Parsing', () => {
     logSpy.mockRestore()
   })
 
+  it('Scenario: Read headers from a file', async () => {
+    // Given a header file, which is how you keep a credential out of the process arguments
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-remote-headers-'))
+    const file = path.join(dir, 'headers.txt')
+    fs.writeFileSync(
+      file,
+      ['# credentials for the example server', 'Authorization: Bearer secret-token', 'X-Tenant:acme', '', '  '].join('\n'),
+    )
+
+    const result = await parseCommandLineArgs(['https://example.remote/server', '--header-file', file], 'usage')
+
+    // Then comments and blank lines are skipped, and values are trimmed as --header trims them
+    expect(result.headers).toEqual({ Authorization: 'Bearer secret-token', 'X-Tenant': 'acme' })
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('Scenario: A header file that cannot be read is fatal', async () => {
+    // Carrying on would send the request unauthenticated and surface far from the real mistake
+    await expect(parseCommandLineArgs(['https://example.remote/server', '--header-file', '/nope/missing.txt'], 'usage')).rejects.toThrow(
+      /Could not read the header file/,
+    )
+  })
+
+  it('Scenario: A malformed line in a header file is reported without its contents', async () => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'mcp-remote-headers-'))
+    const file = path.join(dir, 'headers.txt')
+    fs.writeFileSync(file, ['Authorization Bearer super-secret', 'X-Ok: fine'].join('\n'))
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => void logged.push(a.join(' ')))
+
+    const result = await parseCommandLineArgs(['https://example.remote/server', '--header-file', file], 'usage')
+
+    // The good line still loads, and the bad one is named by line number - it is where a
+    // credential would be if someone forgot the colon
+    expect(result.headers).toEqual({ 'X-Ok': 'fine' })
+    expect(logged.join('\n')).toContain('line 1')
+    expect(logged.join('\n')).not.toContain('super-secret')
+    spy.mockRestore()
+    fs.rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('Scenario: A malformed --header argument is reported without its value', async () => {
+    const logged: string[] = []
+    const spy = vi.spyOn(console, 'error').mockImplementation((...a: unknown[]) => void logged.push(a.join(' ')))
+
+    await parseCommandLineArgs(['https://example.remote/server', '--header', 'Authorization Bearer super-secret'], 'usage')
+
+    expect(logged.join('\n')).not.toContain('super-secret')
+    spy.mockRestore()
+  })
+
   it('Scenario: Ignore invalid header format', async () => {
     // Given command line arguments with an invalid header format
     const args = ['https://example.com/sse', '--header', 'invalid-header-format']

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1181,6 +1181,49 @@ export function parseSecondsOption(args: string[], flag: string, { allowZero = f
   return Math.round(seconds * 1000)
 }
 
+/** Splits `Name: value` into its parts, or undefined if it is not that shape. */
+function parseHeaderLine(line: string): { name: string; value: string } | undefined {
+  const match = line.match(/^([A-Za-z0-9_-]+):\s*(.*)$/)
+  return match ? { name: match[1], value: match[2] } : undefined
+}
+
+/**
+ * Reads headers from a file, one `Name: value` per line, `#` for comments.
+ *
+ * A file exists to keep credentials out of the process arguments, where every other user on the
+ * machine can read them - so a file named but unreadable is fatal rather than a warning. Carrying
+ * on would send the request without its credentials and turn a typo in a path into an
+ * authorization error somewhere much less obvious.
+ *
+ * @param filePath The file to read
+ * @returns The headers it declares
+ */
+async function readHeaderFile(filePath: string): Promise<Record<string, string>> {
+  let contents: string
+  try {
+    contents = await readFile(filePath, 'utf8')
+  } catch (error) {
+    throw new Error(`Could not read the header file ${filePath}: ${(error as Error).message}`)
+  }
+
+  const headers: Record<string, string> = {}
+  contents.split(/\r?\n/).forEach((line, index) => {
+    const trimmed = line.trim()
+    if (!trimmed || trimmed.startsWith('#')) return
+
+    const parsed = parseHeaderLine(trimmed)
+    // By line number, never by content - these lines are exactly where the secrets are
+    if (!parsed) {
+      log(`Warning: ignoring line ${index + 1} of ${filePath}, which is not in Name:Value form`)
+      return
+    }
+    headers[parsed.name] = parsed.value
+  })
+
+  log(`Loaded ${Object.keys(headers).length} header(s) from ${filePath}`)
+  return headers
+}
+
 export async function parseCommandLineArgs(args: string[], usage: string) {
   if (args.includes('--help') || args.includes('-h')) {
     process.stdout.write(`${usage}\n`)
@@ -1200,14 +1243,18 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
   while (i < args.length) {
     if (args[i] === '--header' && i < args.length - 1) {
       const value = args[i + 1]
-      const match = value.match(/^([A-Za-z0-9_-]+):\s*(.*)$/)
-      if (match) {
-        headers[match[1]] = match[2]
-      } else {
-        log(`Warning: ignoring invalid header argument: ${value}`)
-      }
+      const parsed = parseHeaderLine(value)
+      // Never the argument itself: a header that failed to parse is usually one whose value
+      // contains something unexpected, and the value is a credential more often than not.
+      if (parsed) headers[parsed.name] = parsed.value
+      else log('Warning: ignoring a --header argument that is not in Name:Value form')
       args.splice(i, 2)
       // Do not increment i, as the array has shifted
+      continue
+    }
+    if (args[i] === '--header-file' && i < args.length - 1) {
+      Object.assign(headers, await readHeaderFile(args[i + 1]))
+      args.splice(i, 2)
       continue
     }
     i++


### PR DESCRIPTION
Supersedes #80 — the feature is @rkophs's idea, rebuilt on current `main`.

Passing a bearer token as `--header` puts it in the process arguments, where any other user on the machine can read it out of the process list. `--header-file` takes the same headers from a file instead: one `Name: value` per line, `#` for comments.

Four changes from #80:

- **`--header-file`, not `--headerFile`** — every other flag here is kebab-case.
- **An unreadable file is fatal.** #80 logged and carried on, which sends the request without its credentials and surfaces the mistake as an authorization error somewhere much less obvious than "I mistyped the path".
- **Malformed lines are reported by line number, not by content.** A line that fails to parse is usually one whose value contains something unexpected — and a line missing its colon is exactly where a credential would be. #80 logged the whole line.
- **Values are trimmed**, matching `--header`.

Also fixes the same leak on the existing `--header` path, which is pre-existing on `main`:

```
--header "Authorization Bearer super-secret"
  before: Warning: ignoring invalid header argument: Authorization Bearer super-secret
  after:  Warning: ignoring a --header argument that is not in Name:Value form
```

That undercuts dbbac4d, which took care to log header *names* only.

Four tests: a file loads with comments and blanks skipped, an unreadable file throws, a malformed line is named by number with the secret absent from the output, and the same for `--header`.
