### PR TITLE
feat: keep an idle connection alive with --keep-alive

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,20 @@ You can specify multiple `--ignore-tool` flags to ignore different patterns. Exa
       ]
 ```
 
+* To stop an idle connection being dropped, add the `--keep-alive` flag. The proxy then sends a `ping` every 30 seconds, which is enough traffic to keep a server — or a load balancer in front of one — from reaping a session that has been quiet for a few minutes. Use `--ping-interval` with a value in seconds to change the period; setting it turns keep-alive on, so the two flags are only both needed when you want the default period spelled out.
+
+  This is the opposite end of the problem from `--body-timeout`: that one governs how long *we* wait, whereas this keeps the *other* side from hanging up.
+
+```json
+      "args": [
+        "mcp-remote",
+        "https://remote.mcp.server/sse",
+        "--keep-alive",
+        "--ping-interval",
+        "60"
+      ]
+```
+
 * To connect over IPv4 only, add the `--ipv4` flag. Useful when a hostname resolves to both IPv4 and IPv6 addresses but the IPv6 routes silently black-hole rather than being refused — connection attempts then time out instead of failing over, and the request never completes.
 
 ```json

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -65,6 +65,14 @@ export type AuthCodeResult = {
   state?: string
 }
 
+/*
+ * How often, if ever, to ping the remote server so an idle connection is not reaped
+ */
+export interface KeepAliveConfig {
+  enabled: boolean
+  intervalMs: number
+}
+
 // optional tatic OAuth client information
 export type StaticOAuthClientMetadata = OAuthClientMetadata | null | undefined
 export type StaticOAuthClientInformationFull = OAuthClientInformationFull | null | undefined

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -2526,3 +2526,149 @@ describe('Feature: Resource Indicator Flags', () => {
     expect(result.serverUrlHash).toBe(getServerUrlHash('https://example.com/mcp', undefined, {}))
   })
 })
+
+describe('Feature: Keeping an idle connection alive', () => {
+  const mockTransport = () =>
+    ({
+      send: vi.fn().mockResolvedValue(undefined),
+      close: vi.fn().mockResolvedValue(undefined),
+      start: vi.fn().mockResolvedValue(undefined),
+      onmessage: vi.fn(),
+      onclose: vi.fn(),
+      onerror: vi.fn(),
+    }) as unknown as Transport
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('Scenario: Pings the server once per interval while the connection is open', async () => {
+    // Given a proxy set up to keep the connection alive every 30 seconds
+    const transportToClient = mockTransport()
+    const transportToServer = mockTransport()
+    mcpProxy({ transportToClient, transportToServer, keepAlive: { enabled: true, intervalMs: 30_000 } })
+
+    // When two intervals elapse with no other traffic
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    // Then the server has been pinged twice
+    const pings = (transportToServer.send as any).mock.calls.filter(([m]: any[]) => m.method === 'ping')
+    expect(pings).toHaveLength(2)
+    expect(pings[0][0]).toMatchObject({ jsonrpc: '2.0', method: 'ping' })
+  })
+
+  it('Scenario: Without the flag, nothing is sent', async () => {
+    // Given a proxy with no keep-alive configured
+    const transportToClient = mockTransport()
+    const transportToServer = mockTransport()
+    mcpProxy({ transportToClient, transportToServer })
+
+    // When a long time passes
+    await vi.advanceTimersByTimeAsync(10 * 60_000)
+
+    // Then the proxy has sent nothing of its own
+    expect(transportToServer.send).not.toHaveBeenCalled()
+  })
+
+  it('Scenario: The answer to our own ping is consumed, not forwarded to the client', async () => {
+    // Given a proxy that has sent a keep-alive ping
+    const transportToClient = mockTransport()
+    const transportToServer = mockTransport()
+    mcpProxy({ transportToClient, transportToServer, keepAlive: { enabled: true, intervalMs: 30_000 } })
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    const [ping] = (transportToServer.send as any).mock.calls.find(([m]: any[]) => m.method === 'ping')
+
+    // When the server answers it
+    transportToServer.onmessage?.({ jsonrpc: '2.0', id: ping.id, result: {} } as any)
+
+    // Then the client is never handed a response to a request it did not send
+    expect(transportToClient.send).not.toHaveBeenCalled()
+  })
+
+  it("Scenario: A response to the client's own request is still forwarded", async () => {
+    // Given a proxy with keep-alive enabled
+    const transportToClient = mockTransport()
+    const transportToServer = mockTransport()
+    mcpProxy({ transportToClient, transportToServer, keepAlive: { enabled: true, intervalMs: 30_000 } })
+    await vi.advanceTimersByTimeAsync(30_000)
+
+    // When the server answers something the client actually asked for
+    transportToServer.onmessage?.({ jsonrpc: '2.0', id: 'client-1', result: { tools: [] } } as any)
+
+    // Then it reaches the client untouched
+    expect(transportToClient.send).toHaveBeenCalledWith(expect.objectContaining({ id: 'client-1' }))
+  })
+
+  it('Scenario: A ping answer is only swallowed once, so a reused id still reaches the client', async () => {
+    // Given a proxy whose first ping has already been answered
+    const transportToClient = mockTransport()
+    const transportToServer = mockTransport()
+    mcpProxy({ transportToClient, transportToServer, keepAlive: { enabled: true, intervalMs: 30_000 } })
+    await vi.advanceTimersByTimeAsync(30_000)
+    const [ping] = (transportToServer.send as any).mock.calls.find(([m]: any[]) => m.method === 'ping')
+    transportToServer.onmessage?.({ jsonrpc: '2.0', id: ping.id, result: {} } as any)
+
+    // When a later message arrives carrying that same id
+    transportToServer.onmessage?.({ jsonrpc: '2.0', id: ping.id, result: { second: true } } as any)
+
+    // Then it is treated as the client's, because our ping is no longer outstanding
+    expect(transportToClient.send).toHaveBeenCalledWith(expect.objectContaining({ id: ping.id }))
+  })
+
+  it('Scenario: Pinging stops once the connection closes', async () => {
+    // Given a proxy that has been pinging
+    const transportToClient = mockTransport()
+    const transportToServer = mockTransport()
+    mcpProxy({ transportToClient, transportToServer, keepAlive: { enabled: true, intervalMs: 30_000 } })
+    await vi.advanceTimersByTimeAsync(30_000)
+    const before = (transportToServer.send as any).mock.calls.length
+
+    // When the remote end closes
+    transportToServer.onclose?.()
+    await vi.advanceTimersByTimeAsync(5 * 60_000)
+
+    // Then no further pings are sent
+    expect((transportToServer.send as any).mock.calls.length).toBe(before)
+  })
+
+  it('Scenario: A failed ping is reported without taking the proxy down', async () => {
+    // Given a server that refuses the ping
+    const transportToClient = mockTransport()
+    const transportToServer = mockTransport()
+    ;(transportToServer.send as any).mockRejectedValue(new Error('socket hang up'))
+    mcpProxy({ transportToClient, transportToServer, keepAlive: { enabled: true, intervalMs: 30_000 } })
+
+    // When intervals elapse
+    await vi.advanceTimersByTimeAsync(60_000)
+
+    // Then it keeps trying rather than giving up after the first failure
+    expect((transportToServer.send as any).mock.calls.length).toBe(2)
+  })
+})
+
+describe('Feature: Keep-alive command line flags', () => {
+  it('Scenario: Off unless asked for', async () => {
+    const result = await parseCommandLineArgs(['https://example.com/mcp'], 'usage')
+    expect(result.keepAlive.enabled).toBe(false)
+  })
+
+  it('Scenario: --keep-alive pings every 30 seconds by default', async () => {
+    const result = await parseCommandLineArgs(['https://example.com/mcp', '--keep-alive'], 'usage')
+    expect(result.keepAlive).toEqual({ enabled: true, intervalMs: 30_000 })
+  })
+
+  it('Scenario: --ping-interval sets the interval and implies --keep-alive', async () => {
+    const result = await parseCommandLineArgs(['https://example.com/mcp', '--ping-interval', '10'], 'usage')
+    expect(result.keepAlive).toEqual({ enabled: true, intervalMs: 10_000 })
+  })
+
+  it('Scenario: An unusable interval falls back to the default rather than disabling the flag', async () => {
+    const result = await parseCommandLineArgs(['https://example.com/mcp', '--keep-alive', '--ping-interval', 'soon'], 'usage')
+    expect(result.keepAlive).toEqual({ enabled: true, intervalMs: 30_000 })
+  })
+})

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -5,7 +5,13 @@ import { StreamableHTTPClientTransport, StreamableHTTPError } from '@modelcontex
 import { Transport, type FetchLike } from '@modelcontextprotocol/sdk/shared/transport.js'
 import { OAuthError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
 import { OAuthClientInformationFull, OAuthClientInformationFullSchema } from '@modelcontextprotocol/sdk/shared/auth.js'
-import { AuthCodeResult, OAuthCallbackServerOptions, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './types'
+import {
+  AuthCodeResult,
+  KeepAliveConfig,
+  OAuthCallbackServerOptions,
+  StaticOAuthClientInformationFull,
+  StaticOAuthClientMetadata,
+} from './types'
 import { getConfigDir, getConfigFilePath, readJsonFile } from './mcp-auth-config'
 import {
   discoverProtectedResourceMetadata,
@@ -32,6 +38,7 @@ declare global {
 // Connection constants
 export const REASON_AUTH_NEEDED = 'authentication-needed'
 export const REASON_TRANSPORT_FALLBACK = 'falling-back-to-alternate-transport'
+export const DEFAULT_KEEP_ALIVE_INTERVAL_MS = 30_000
 
 /**
  * Which JSON-RPC methods carry an `Mcp-Name`, and where its value comes from.
@@ -260,11 +267,14 @@ export function mcpProxy({
   transportToClient,
   transportToServer,
   ignoredTools = [],
+  keepAlive,
   reauthorize,
 }: {
   transportToClient: Transport
   transportToServer: Transport
   ignoredTools?: string[]
+  /** Pings the server on an interval, so a connection carrying no traffic is not reaped */
+  keepAlive?: KeepAliveConfig
   /**
    * Completes a sign-in for a request the server refused, or undefined to answer with the error.
    *
@@ -280,6 +290,9 @@ export function mcpProxy({
   let lastInitialize: Message | null = null
   let reinitSeq = 0
   const pendingReinit = new Map<string, (message: Message) => void>()
+  const pendingPings = new Set<string>()
+  let pingSeq = 0
+  let keepAliveTimer: NodeJS.Timeout | null = null
   let initializedDelivered: Promise<unknown> | null = null
   let reauthorizeInFlight: Promise<void> | null = null
 
@@ -355,11 +368,18 @@ export function mcpProxy({
   }
 
   transportToServer.onmessage = (_message) => {
+    const incomingId = (_message as any).id
+
+    // Answers to our own keep-alive pings are ours to consume too. The client never sent the
+    // request, so forwarding the response would hand it an id it has nothing to match against.
+    if (typeof incomingId === 'string' && pendingPings.delete(incomingId)) {
+      return
+    }
+
     // Responses to our own re-initialize handshake are ours to consume, not the client's
-    const reinitId = (_message as any).id
-    if (typeof reinitId === 'string' && pendingReinit.has(reinitId)) {
-      const settle = pendingReinit.get(reinitId)!
-      pendingReinit.delete(reinitId)
+    if (typeof incomingId === 'string' && pendingReinit.has(incomingId)) {
+      const settle = pendingReinit.get(incomingId)!
+      pendingReinit.delete(incomingId)
       settle(_message as any)
       return
     }
@@ -389,6 +409,7 @@ export function mcpProxy({
   }
 
   transportToClient.onclose = () => {
+    stopKeepAlive()
     if (transportToServerClosed) {
       return
     }
@@ -399,6 +420,7 @@ export function mcpProxy({
   }
 
   transportToServer.onclose = () => {
+    stopKeepAlive()
     if (transportToClientClosed) {
       return
     }
@@ -409,6 +431,10 @@ export function mcpProxy({
 
   transportToClient.onerror = onClientError
   transportToServer.onerror = onServerError
+
+  if (keepAlive?.enabled) {
+    keepAliveTimer = startKeepAlive(keepAlive.intervalMs)
+  }
 
   function onClientError(error: Error) {
     log('Error from local client:', error)
@@ -495,6 +521,42 @@ export function mcpProxy({
     // per session - subscriptions, roots, progress tokens - is quietly gone. The
     // spec mandates the new session anyway; there is no way to replay that state.
     log(`Re-established session ${transportToServer.sessionId ?? '(none)'} after server expiry`)
+  }
+
+  /**
+   * Pings the server on an interval so a connection carrying no traffic is not reaped.
+   *
+   * Servers - and the load balancers in front of them - commonly close a connection that has been
+   * idle for a few minutes. Nothing surfaces that to the client until its next request fails, so
+   * for a session that is mostly idle a cheap request on a timer is what keeps it usable.
+   *
+   * Every id here is ours, and so is every answer: they are recorded in `pendingPings` and dropped
+   * in the remote handler instead of being forwarded.
+   */
+  function startKeepAlive(intervalMs: number) {
+    const timer = setInterval(() => {
+      const id = `mcp-remote-keepalive-${++pingSeq}`
+      pendingPings.add(id)
+      transportToServer.send({ jsonrpc: '2.0', id, method: 'ping' }).catch((error) => {
+        // A failed ping is not fatal on its own - the next request is what decides whether the
+        // connection is really gone - so this is reported rather than escalated.
+        pendingPings.delete(id)
+        log(`Keep-alive ping failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    }, intervalMs)
+
+    // Waiting to send another ping is never a reason to hold the process open
+    timer.unref?.()
+    log(`Keep-alive enabled, pinging every ${intervalMs / 1000} seconds`)
+    return timer
+  }
+
+  function stopKeepAlive() {
+    if (keepAliveTimer) {
+      clearInterval(keepAliveTimer)
+      keepAliveTimer = null
+    }
+    pendingPings.clear()
   }
 
   /**
@@ -1414,6 +1476,14 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     setGlobalDispatcher(new Agent(dispatcherOptions))
   }
 
+  // Keep-alive. `--ping-interval` implies `--keep-alive`, because an interval that silently does
+  // nothing unless a second flag is also present is the more surprising reading of the two.
+  const pingIntervalMs = parseSecondsOption(args, '--ping-interval')
+  const keepAlive: KeepAliveConfig = {
+    enabled: args.includes('--keep-alive') || pingIntervalMs !== undefined,
+    intervalMs: pingIntervalMs ?? DEFAULT_KEEP_ALIVE_INTERVAL_MS,
+  }
+
   // Parse transport strategy
   let transportStrategy: TransportStrategy = 'http-first' // Default
   const transportIndex = args.indexOf('--transport')
@@ -1626,6 +1696,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     ignoredTools,
     authTimeoutMs,
     serverUrlHash,
+    keepAlive,
   }
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -22,7 +22,7 @@ import {
   TransportStrategy,
   discoverOAuthServerInfo,
 } from './lib/utils'
-import { StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
+import { KeepAliveConfig, StaticOAuthClientInformationFull, StaticOAuthClientMetadata } from './lib/types'
 import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
 import { createLazyAuthCoordinator, hasUsableTokens, serverIssuesAuthChallenge } from './lib/coordination'
 
@@ -50,6 +50,7 @@ async function runProxy(
   ignoredTools: string[],
   authTimeoutMs: number,
   serverUrlHash: string,
+  keepAlive: KeepAliveConfig,
 ) {
   // Set up event emitter for auth flow
   const events = new EventEmitter()
@@ -138,6 +139,7 @@ async function runProxy(
       transportToClient: localTransport,
       transportToServer: remoteTransport,
       ignoredTools,
+      keepAlive,
       /**
        * Finishes a sign-in the remote server asked for mid-session.
        *
@@ -236,6 +238,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote <https://server-u
       ignoredTools,
       authTimeoutMs,
       serverUrlHash,
+      keepAlive,
     }) => {
       return runProxy(
         serverUrl,
@@ -252,6 +255,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote <https://server-u
         ignoredTools,
         authTimeoutMs,
         serverUrlHash,
+        keepAlive,
       )
     },
   )


### PR DESCRIPTION
Supersedes #70. The feature, both flag names, and the 30-second default are @ooojustin's — this reworks the implementation to fit where the proxy has since moved.

**The problem with sending the ping from outside the proxy.** #70 put the interval on the remote transport directly, so the server's answer came back through `transportToServer.onmessage` and was forwarded straight to the client — which never sent that request and has no way to match the id. `mcpProxy` already has an idiom for exactly this, from the re-initialize handshake: keep the ids in a pending set and consume the answers instead of forwarding them. Keep-alive now lives in `mcpProxy` for that reason, and owns its own id space.

Other changes:

- **`--ping-interval` implies `--keep-alive`.** Setting an interval that silently does nothing unless a second flag is present is the more surprising reading.
- **Interval is parsed with `parseSecondsOption`**, so it warns and falls back like the other timing flags rather than accepting `NaN`. (The original had a seconds/ms mixup here, which @ooojustin had already spotted.)
- **The timer is `unref`'d**, so waiting to send the next ping never holds the process open.
- **Stops on close** from either end, before the early returns that the existing close handlers take.
- A failed ping is logged and retried rather than escalated — the next real request is what decides whether the connection is actually gone.

**Verification.** 11 new tests; I checked the response-leak one fails without its fix. Full suite 266 passing, `pnpm lint` clean. Also ran the built proxy against a local server that counts what it receives: 5 pings arrived with `mcp-remote-keepalive-*` ids while the client saw only its own ids `1` and `2`, with `initialize` and `tools/list` both answered normally. Same result against live `docs.mcp.cloudflare.com`.

This is the opposite end of the problem from `--body-timeout`: that bounds how long *we* wait, this keeps the *other* side from hanging up.