### PR TITLE
Don't lose authorization due to short network outage

### DIFF
--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -569,6 +569,25 @@ describe('NodeOAuthClientProvider - OAuth Scope Handling', () => {
       expect(mockDeleteConfigFile).not.toHaveBeenCalled()
     })
 
+    it('keeps the sign-in when nothing describes the scope to ask for', async () => {
+      provider = new NodeOAuthClientProvider(defaultOptions)
+      storedWith('openid profile offline_access')
+
+      await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'at' })
+      expect(mockDeleteConfigFile).not.toHaveBeenCalled()
+    })
+
+    it('signs in again when a server advertises the same scopes the fallback happens to name', async () => {
+      provider = new NodeOAuthClientProvider({
+        ...defaultOptions,
+        protectedResourceMetadata: { resource: 'https://example.com', scopes_supported: ['openid', 'email', 'profile'] } as any,
+      })
+      storedWith('openid profile offline_access')
+
+      await expect(provider.tokens()).resolves.toBeUndefined()
+      expect(mockDeleteConfigFile).toHaveBeenCalledWith('test-hash', 'tokens.json')
+    })
+
     it('reuses a token when the configuration has not changed', async () => {
       provider = new NodeOAuthClientProvider({ ...defaultOptions, staticOAuthClientMetadata: { scope: 'a.read' } as any })
       storedWith('a.read')

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -34,6 +34,8 @@ export const OAuthTokensWithExpiresAtSchema = OAuthTokensSchema.extend({
 })
 type OAuthTokensWithExpiresAt = z.infer<typeof OAuthTokensWithExpiresAtSchema>
 
+const FALLBACK_SCOPE = 'openid email profile'
+
 /** The shape of the state we issue, and the only shape accepted into a config filename. */
 const ISSUED_STATE = /^[A-Za-z0-9-]{1,64}$/
 
@@ -279,6 +281,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   }
 
   private getEffectiveScope(): string {
+    return this.requestedScope() ?? FALLBACK_SCOPE
+  }
+
+  private requestedScope(): string | undefined {
     // Priority 1: User-provided scope from staticOAuthClientMetadata (highest priority)
     if (this.staticOAuthClientMetadata?.scope && this.staticOAuthClientMetadata.scope.trim().length > 0) {
       debugLog('Using scope from staticOAuthClientMetadata', { scope: this.staticOAuthClientMetadata.scope })
@@ -327,9 +333,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       return scope
     }
 
-    // Priority 6: Fallback to hardcoded default when metadata is unknown or omits scopes_supported
-    debugLog('Using fallback default scope')
-    return 'openid email profile'
+    debugLog('No source describes the scope to request')
+    return undefined
   }
 
   /**
@@ -550,7 +555,9 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    */
   private scopeRequestChanged(tokens: OAuthTokensWithExpiresAt): boolean {
     if (tokens.requested_scope === undefined) return false
-    return tokens.requested_scope !== this.getEffectiveScope()
+    const requested = this.requestedScope()
+    if (requested === undefined) return false
+    return tokens.requested_scope !== requested
   }
 
   /**


### PR DESCRIPTION
When usable tokens are already stored and the client starts while the server is briefly unreachable - a network blip, a pod restart - discovery produces nothing. `main` reads that as a scope change and calls `invalidateCredentials`, so the tokens are gone.

A failed discovery does not say the scope changed. It says we do not know what the scope should be. `getEffectiveScope()` has no way to express that: its last branch returns a hardcoded default, which is then compared against what the token was obtained for and, of course, differs.

## Observed

Against a real deployment, with a node eviction moving the pod to another one:

```
[1902439] Discovering OAuth server configuration...
[1902439] Connecting to remote server: https://.../mcp
[1902439] The scopes this client asks for have changed since it signed in; signing in again
[1902439] Connection error: StreamableHTTPError: Error POSTing to endpoint: 503 Service Temporarily Unavailable
```

The `Discovered authorization server` line is missing, unlike every successful start. About twenty seconds of downtime cost a sign-in that was otherwise good for two weeks, and the refresh token that went with it.

## The change

The credentials are left alone when nothing describes the scope to ask for. Once the server is back they are tried again and generally work - one browser flow fewer.

The distinction is by provenance, not by string: the check is skipped only when no source produced a scope at all. A server that genuinely advertises the same scopes the fallback happens to name is still compared normally, which the second test covers.

Introduced in #341, so `0.4.0` and later.

## What it does not do

It does not add a retry. The connection still fails and the server stays disconnected until it is started again. That is a separate concern - a retry needs backoff, a bound, and agreement with how the host restarts servers - and mixing the two would make both harder to review.
