### PR TITLE
Spend a rotating refresh token once per host, not once per instance

### DIFF
--- a/src/lib/mcp-auth-config.test.ts
+++ b/src/lib/mcp-auth-config.test.ts
@@ -2,7 +2,15 @@ import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
 import fs from 'fs/promises'
 import os from 'os'
 import path from 'path'
-import { writeJsonFile, getConfigFilePath, deleteStaleConfigFiles, getConfigDir } from './mcp-auth-config'
+import {
+  writeJsonFile,
+  getConfigFilePath,
+  deleteStaleConfigFiles,
+  getConfigDir,
+  acquireConfigLease,
+  readConfigLease,
+  releaseConfigLease,
+} from './mcp-auth-config'
 
 vi.mock('./utils', () => ({
   log: vi.fn(),
@@ -126,5 +134,86 @@ describe('Feature: Sweeping files nothing will name again', () => {
 
     await fs.unlink(inFlight).catch(() => {})
     await fs.unlink(unrelated).catch(() => {})
+  })
+})
+
+describe('Feature: Leasing a filename to one instance at a time', () => {
+  const hash = 'lease-test'
+  const filename = 'refresh_in_progress.json'
+  const TTL = 30_000
+  const leaseOnDisk = async () => JSON.parse(await fs.readFile(getConfigFilePath(hash, filename), 'utf-8'))
+  const writeFileInStore = async (contents: string) => {
+    await fs.mkdir(getConfigDir(), { recursive: true })
+    await fs.writeFile(getConfigFilePath(hash, filename), contents, 'utf-8')
+  }
+  const writeLease = (lease: Record<string, unknown>) => writeFileInStore(JSON.stringify(lease))
+
+  // A pid nothing can be running under: the kernel rejects it outright, so it can never be reused
+  const DEAD_PID = 0x7fffffff
+
+  it('Scenario: Several instances race and exactly one comes away with the lease', async () => {
+    const claims = await Promise.all(Array.from({ length: 8 }, () => acquireConfigLease(hash, filename, TTL)))
+
+    // A refresh token spent twice is a revoked chain, so "roughly one winner" is not good enough
+    expect(claims.filter(Boolean)).toHaveLength(1)
+    expect((await leaseOnDisk()).nonce).toBe(claims.find(Boolean))
+  })
+
+  it('Scenario: An instance that is still working keeps its lease', async () => {
+    expect(await acquireConfigLease(hash, filename, TTL)).toBeTruthy()
+
+    expect(await acquireConfigLease(hash, filename, TTL)).toBeUndefined()
+    expect((await readConfigLease(hash, filename, TTL))?.live).toBe(true)
+  })
+
+  it('Scenario: A lease its owner died holding is taken over at once', async () => {
+    // Killed mid-refresh a moment ago. Waiting out the age of a lease nobody will ever release
+    // stalls every other instance for the whole of it.
+    await writeLease({ pid: DEAD_PID, nonce: 'theirs', at: Date.now() })
+
+    expect(await readConfigLease(hash, filename, TTL)).toMatchObject({ live: false })
+    expect(await acquireConfigLease(hash, filename, TTL)).toBeTruthy()
+    expect((await leaseOnDisk()).pid).toBe(process.pid)
+  })
+
+  it('Scenario: A live owner that has run past its deadline stops holding everyone up', async () => {
+    await writeLease({ pid: process.pid, nonce: 'theirs', at: Date.now() - TTL - 1 })
+
+    expect(await readConfigLease(hash, filename, TTL)).toMatchObject({ live: false })
+    expect(await acquireConfigLease(hash, filename, TTL)).toBeTruthy()
+  })
+
+  it('Scenario: A lease nothing can make sense of is not left blocking everyone', async () => {
+    await writeFileInStore('not json at all')
+
+    expect(await readConfigLease(hash, filename, TTL)).toBeUndefined()
+    expect(await acquireConfigLease(hash, filename, TTL)).toBeTruthy()
+  })
+
+  it('Scenario: Releasing only clears a lease this instance still holds', async () => {
+    const nonce = await acquireConfigLease(hash, filename, TTL)
+    // Overran its deadline, and a sibling has since taken over
+    await writeLease({ pid: process.pid, nonce: 'somebody-else', at: Date.now() })
+
+    await releaseConfigLease(hash, filename, nonce!)
+
+    // Deleting it would hand the same work to a third instance
+    expect((await leaseOnDisk()).nonce).toBe('somebody-else')
+  })
+
+  it('Scenario: Releasing frees the filename for the next instance', async () => {
+    const nonce = await acquireConfigLease(hash, filename, TTL)
+
+    await releaseConfigLease(hash, filename, nonce!)
+
+    expect(await readConfigLease(hash, filename, TTL)).toBeUndefined()
+    expect(await acquireConfigLease(hash, filename, TTL)).toBeTruthy()
+  })
+
+  it('Scenario: The lease is readable only by its owner', async () => {
+    await acquireConfigLease(hash, filename, TTL)
+
+    const mode = (await fs.stat(getConfigFilePath(hash, filename))).mode & 0o777
+    expect(mode).toBe(0o600)
   })
 })

--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -134,6 +134,35 @@ export async function deleteStaleConfigFiles(serverUrlHash: string, prefix: stri
  * @param schema The schema to validate against
  * @returns The parsed file content or undefined if the file doesn't exist
  */
+/**
+ * Creates a config file only if no live one exists, so concurrent instances agree on a single winner
+ * @param serverUrlHash The hash of the server URL
+ * @param filename The name of the file to create
+ * @param data The data to write
+ * @param maxAgeMs How old an existing file must be before it is treated as left by a dead instance
+ * @returns True if this call created the file
+ */
+export async function claimConfigFile(serverUrlHash: string, filename: string, data: any, maxAgeMs: number): Promise<boolean> {
+  await ensureConfigDir()
+  const filePath = getConfigFilePath(serverUrlHash, filename)
+
+  for (const attempt of [0, 1]) {
+    try {
+      await fs.writeFile(filePath, JSON.stringify(data, null, 2), { encoding: 'utf-8', mode: 0o600, flag: 'wx' })
+      return true
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || attempt > 0) return false
+      try {
+        if ((await fs.stat(filePath)).mtimeMs > Date.now() - maxAgeMs) return false
+        await fs.unlink(filePath)
+      } catch {
+        return false
+      }
+    }
+  }
+  return false
+}
+
 export async function readJsonFile<T>(serverUrlHash: string, filename: string, schema: any): Promise<T | undefined> {
   try {
     await ensureConfigDir()

--- a/src/lib/mcp-auth-config.ts
+++ b/src/lib/mcp-auth-config.ts
@@ -1,6 +1,8 @@
 import path from 'path'
 import os from 'os'
 import fs from 'fs/promises'
+import { randomUUID } from 'node:crypto'
+import { z } from 'zod'
 import { log, debugLog } from './utils'
 
 /**
@@ -134,35 +136,6 @@ export async function deleteStaleConfigFiles(serverUrlHash: string, prefix: stri
  * @param schema The schema to validate against
  * @returns The parsed file content or undefined if the file doesn't exist
  */
-/**
- * Creates a config file only if no live one exists, so concurrent instances agree on a single winner
- * @param serverUrlHash The hash of the server URL
- * @param filename The name of the file to create
- * @param data The data to write
- * @param maxAgeMs How old an existing file must be before it is treated as left by a dead instance
- * @returns True if this call created the file
- */
-export async function claimConfigFile(serverUrlHash: string, filename: string, data: any, maxAgeMs: number): Promise<boolean> {
-  await ensureConfigDir()
-  const filePath = getConfigFilePath(serverUrlHash, filename)
-
-  for (const attempt of [0, 1]) {
-    try {
-      await fs.writeFile(filePath, JSON.stringify(data, null, 2), { encoding: 'utf-8', mode: 0o600, flag: 'wx' })
-      return true
-    } catch (error) {
-      if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || attempt > 0) return false
-      try {
-        if ((await fs.stat(filePath)).mtimeMs > Date.now() - maxAgeMs) return false
-        await fs.unlink(filePath)
-      } catch {
-        return false
-      }
-    }
-  }
-  return false
-}
-
 export async function readJsonFile<T>(serverUrlHash: string, filename: string, schema: any): Promise<T | undefined> {
   try {
     await ensureConfigDir()
@@ -256,4 +229,107 @@ export async function writeTextFile(serverUrlHash: string, filename: string, tex
     log(`Error writing ${filename}:`, error)
     throw error
   }
+}
+
+/**
+ * A lease records who took it and when, so a challenger can tell an owner still working from one
+ * that will never come back. The nonce is the part no other instance can guess, which is what
+ * makes ownership checkable after the fact.
+ */
+const ConfigLeaseSchema = z.object({ pid: z.number().int().positive(), nonce: z.string().min(1), at: z.number() })
+
+/** A lease read off disk, with whether its owner still appears to hold it. */
+export type ConfigLease = z.infer<typeof ConfigLeaseSchema> & { live: boolean }
+
+/**
+ * Whether a process still exists.
+ *
+ * Signal 0 sends nothing; it only asks the kernel to do the permission and existence checks it
+ * would do for a real signal. EPERM means the process is there and belongs to someone else.
+ */
+function processIsAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0)
+    return true
+  } catch (error) {
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
+  }
+}
+
+/**
+ * Takes a lease on a filename, naming this process as its owner.
+ *
+ * The claim itself is one `O_CREAT|O_EXCL` write, so the kernel picks the winner and no two
+ * instances can create the same file. What a file cannot do is release itself when its owner
+ * dies, so the lease also records a pid and a timestamp: an owner that no longer exists is gone
+ * for good and its lease is taken immediately, and one that exists but has held the lease past
+ * `maxAgeMs` is treated the same way, since a wedged instance would otherwise block every other
+ * one forever.
+ *
+ * Clearing an abandoned lease is not atomic on its own - two challengers can each delete what
+ * they found and each create their own - so a claim is only trusted once the file is read back
+ * and still carries the nonce this call wrote.
+ *
+ * @param serverUrlHash The hash of the server URL
+ * @param filename The name of the lease file
+ * @param maxAgeMs How long an owner may hold the lease before a challenger may take it
+ * @returns The nonce identifying this lease, or undefined if another instance holds it
+ */
+export async function acquireConfigLease(serverUrlHash: string, filename: string, maxAgeMs: number): Promise<string | undefined> {
+  await ensureConfigDir()
+  const filePath = getConfigFilePath(serverUrlHash, filename)
+  const nonce = randomUUID()
+
+  // At most one round of clearing an abandoned lease, so a filename nothing can hold - a
+  // directory, say - cannot spin here.
+  for (const attempt of [0, 1]) {
+    try {
+      const lease = { pid: process.pid, nonce, at: Date.now() }
+      await fs.writeFile(filePath, JSON.stringify(lease, null, 2), { encoding: 'utf-8', mode: 0o600, flag: 'wx' })
+      return (await readLeaseFile(serverUrlHash, filename))?.nonce === nonce ? nonce : undefined
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== 'EEXIST' || attempt > 0) return undefined
+
+      const held = await readConfigLease(serverUrlHash, filename, maxAgeMs)
+      if (held?.live) return undefined
+
+      // Abandoned, or unreadable and so of no use to whoever wrote it either
+      debugLog('Clearing an abandoned lease', { filename, heldBy: held?.pid })
+      await fs.unlink(filePath).catch(() => {})
+    }
+  }
+  return undefined
+}
+
+/** @returns The lease on disk, or undefined if there is none or it cannot be read */
+async function readLeaseFile(serverUrlHash: string, filename: string): Promise<z.infer<typeof ConfigLeaseSchema> | undefined> {
+  return readJsonFile<z.infer<typeof ConfigLeaseSchema>>(serverUrlHash, filename, ConfigLeaseSchema)
+}
+
+/**
+ * Reads the lease on a filename, if one is held
+ * @param serverUrlHash The hash of the server URL
+ * @param filename The name of the lease file
+ * @param maxAgeMs How long an owner may hold the lease before a challenger may take it
+ * @returns The lease and whether its owner still holds it, or undefined if nobody does
+ */
+export async function readConfigLease(serverUrlHash: string, filename: string, maxAgeMs: number): Promise<ConfigLease | undefined> {
+  const lease = await readLeaseFile(serverUrlHash, filename)
+  if (!lease) return undefined
+  return { ...lease, live: Date.now() - lease.at < maxAgeMs && processIsAlive(lease.pid) }
+}
+
+/**
+ * Releases a lease, if this instance still holds it.
+ *
+ * An owner that ran past `maxAgeMs` may find the lease already taken by someone else, and
+ * deleting that one would hand the same work to a third instance.
+ *
+ * @param serverUrlHash The hash of the server URL
+ * @param filename The name of the lease file
+ * @param nonce The nonce returned when the lease was acquired
+ */
+export async function releaseConfigLease(serverUrlHash: string, filename: string, nonce: string): Promise<void> {
+  if ((await readLeaseFile(serverUrlHash, filename))?.nonce !== nonce) return
+  await deleteConfigFile(serverUrlHash, filename)
 }

--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -1051,6 +1051,7 @@ describe('NodeOAuthClientProvider - proactive token refresh', () => {
     mockRefresh = vi.mocked(refreshAuthorization)
     mockWriteJsonFile.mockResolvedValue(undefined)
     vi.mocked(mcpAuthConfig.deleteConfigFile).mockResolvedValue(undefined)
+    vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(true)
 
     // Any client_info read hands back a registered client; tokens.json is per-test
     mockReadJsonFile.mockImplementation(async (_hash: string, file: string) =>
@@ -1102,6 +1103,17 @@ describe('NodeOAuthClientProvider - proactive token refresh', () => {
     expect(mockRefresh).toHaveBeenCalledTimes(1)
     expect(mockRefresh.mock.calls[0][1].refreshToken).toBe('r1')
     expect(result?.access_token).toBe('fresh-token')
+  })
+
+  it('Scenario: an instance waits for the sibling already refreshing rather than spending the token twice', async () => {
+    const expired = storedTokens({ expires_at: Date.now() - 1000 })
+    const renewed = storedTokens({ access_token: 'from-sibling', refresh_token: 'r2', expires_at: Date.now() + 3_600_000 })
+    mockReadJsonFile.mockResolvedValueOnce(expired).mockResolvedValue(renewed)
+    vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(false)
+    const provider = new NodeOAuthClientProvider(options)
+
+    await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'from-sibling' })
+    expect(mockRefresh).not.toHaveBeenCalled()
   })
 
   it('Scenario: concurrent requests share a single refresh', async () => {
@@ -1246,6 +1258,7 @@ describe('NodeOAuthClientProvider - Extra authorization parameters', () => {
     vi.mocked(mcpAuthConfig.readJsonFile).mockResolvedValue(undefined)
     vi.mocked(mcpAuthConfig.writeJsonFile).mockResolvedValue(undefined)
     vi.mocked(mcpAuthConfig.deleteConfigFile).mockResolvedValue(undefined)
+    vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(true)
   })
 
   afterEach(() => {

--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -1051,7 +1051,8 @@ describe('NodeOAuthClientProvider - proactive token refresh', () => {
     mockRefresh = vi.mocked(refreshAuthorization)
     mockWriteJsonFile.mockResolvedValue(undefined)
     vi.mocked(mcpAuthConfig.deleteConfigFile).mockResolvedValue(undefined)
-    vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(true)
+    vi.mocked(mcpAuthConfig.acquireConfigLease).mockResolvedValue('lease-1')
+    vi.mocked(mcpAuthConfig.releaseConfigLease).mockResolvedValue(undefined)
 
     // Any client_info read hands back a registered client; tokens.json is per-test
     mockReadJsonFile.mockImplementation(async (_hash: string, file: string) =>
@@ -1105,15 +1106,69 @@ describe('NodeOAuthClientProvider - proactive token refresh', () => {
     expect(result?.access_token).toBe('fresh-token')
   })
 
+  const heldLease = (overrides: Record<string, unknown> = {}) => ({ pid: 4242, nonce: 'theirs', at: Date.now(), live: true, ...overrides })
+
   it('Scenario: an instance waits for the sibling already refreshing rather than spending the token twice', async () => {
     const expired = storedTokens({ expires_at: Date.now() - 1000 })
     const renewed = storedTokens({ access_token: 'from-sibling', refresh_token: 'r2', expires_at: Date.now() + 3_600_000 })
     mockReadJsonFile.mockResolvedValueOnce(expired).mockResolvedValue(renewed)
-    vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(false)
+    vi.mocked(mcpAuthConfig.acquireConfigLease).mockResolvedValue(undefined)
+    vi.mocked(mcpAuthConfig.readConfigLease).mockResolvedValue(heldLease())
     const provider = new NodeOAuthClientProvider(options)
 
     await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'from-sibling' })
+    // The whole point: one refresh_token use per host, not one per instance
     expect(mockRefresh).not.toHaveBeenCalled()
+  })
+
+  it('Scenario: a lease its owner died holding is taken over rather than waited out', async () => {
+    withStoredTokens(storedTokens({ expires_at: Date.now() - 1000 }))
+    mockRefresh.mockResolvedValue({ access_token: 'fresh-token', refresh_token: 'r2', token_type: 'Bearer', expires_in: 3600 })
+    vi.mocked(mcpAuthConfig.acquireConfigLease).mockResolvedValueOnce(undefined).mockResolvedValue('lease-2')
+    // An instance killed mid-refresh leaves its lease behind; nothing will ever release it
+    vi.mocked(mcpAuthConfig.readConfigLease).mockResolvedValue(heldLease({ live: false }))
+    const provider = new NodeOAuthClientProvider(options)
+
+    await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'fresh-token' })
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+  })
+
+  it('Scenario: a sibling that finished without a token is not followed by a second attempt', async () => {
+    withStoredTokens(storedTokens({ expires_at: Date.now() - 1000 }))
+    vi.mocked(mcpAuthConfig.acquireConfigLease).mockResolvedValue(undefined)
+    // The lease is released whether the refresh worked or not, so its absence says the sibling
+    // has had its turn - and retrying a token it may already have spent is the storm being avoided
+    vi.mocked(mcpAuthConfig.readConfigLease).mockResolvedValue(undefined)
+    const provider = new NodeOAuthClientProvider(options)
+
+    await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'stale-token' })
+    expect(mockRefresh).not.toHaveBeenCalled()
+    expect(vi.mocked(mcpAuthConfig.acquireConfigLease)).toHaveBeenCalledTimes(1)
+  })
+
+  it('Scenario: the token redeemed is the one on disk once the lease is held', async () => {
+    // A sibling rotated between this instance reading the token and winning the lease. Redeeming
+    // what was read would spend a token the server has already retired.
+    mockReadJsonFile
+      .mockResolvedValueOnce(storedTokens({ expires_at: Date.now() - 1000 }))
+      .mockResolvedValue(storedTokens({ refresh_token: 'r-rotated', expires_at: Date.now() - 1000 }))
+    mockRefresh.mockResolvedValue({ access_token: 'fresh-token', refresh_token: 'r3', token_type: 'Bearer', expires_in: 3600 })
+    const provider = new NodeOAuthClientProvider(options)
+
+    await provider.tokens()
+
+    expect(mockRefresh.mock.calls[0][1].refreshToken).toBe('r-rotated')
+  })
+
+  it('Scenario: a lease that cannot be taken at all does not fail the request', async () => {
+    withStoredTokens(storedTokens({ expires_at: Date.now() - 1000 }))
+    mockRefresh.mockResolvedValue({ access_token: 'fresh-token', refresh_token: 'r2', token_type: 'Bearer', expires_in: 3600 })
+    vi.mocked(mcpAuthConfig.acquireConfigLease).mockRejectedValue(new Error('EACCES'))
+    const provider = new NodeOAuthClientProvider(options)
+
+    // tokens() runs on every outgoing request; an unwritable store is for the refresh to report
+    await expect(provider.tokens()).resolves.toMatchObject({ access_token: 'fresh-token' })
+    expect(vi.mocked(mcpAuthConfig.releaseConfigLease)).not.toHaveBeenCalled()
   })
 
   it('Scenario: concurrent requests share a single refresh', async () => {
@@ -1258,7 +1313,7 @@ describe('NodeOAuthClientProvider - Extra authorization parameters', () => {
     vi.mocked(mcpAuthConfig.readJsonFile).mockResolvedValue(undefined)
     vi.mocked(mcpAuthConfig.writeJsonFile).mockResolvedValue(undefined)
     vi.mocked(mcpAuthConfig.deleteConfigFile).mockResolvedValue(undefined)
-    vi.mocked(mcpAuthConfig.claimConfigFile).mockResolvedValue(true)
+    vi.mocked(mcpAuthConfig.acquireConfigLease).mockResolvedValue('lease-1')
   })
 
   afterEach(() => {

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -10,7 +10,15 @@ import {
 } from '@modelcontextprotocol/sdk/shared/auth.js'
 import { type OAuthProviderOptions, type StaticOAuthClientInformationFull, type StaticOAuthClientMetadata } from './types'
 import { InvalidClientError, UnauthorizedClientError } from '@modelcontextprotocol/sdk/server/auth/errors.js'
-import { readJsonFile, writeJsonFile, readTextFile, writeTextFile, deleteConfigFile, deleteStaleConfigFiles } from './mcp-auth-config'
+import {
+  readJsonFile,
+  writeJsonFile,
+  readTextFile,
+  writeTextFile,
+  deleteConfigFile,
+  deleteStaleConfigFiles,
+  claimConfigFile,
+} from './mcp-auth-config'
 import { openBrowser } from './open-browser'
 import { log, debugLog, buildRedirectUrl, MCP_REMOTE_VERSION } from './utils'
 import { sanitizeUrl } from 'strict-url-sanitise'
@@ -51,6 +59,10 @@ const CODE_VERIFIER_PREFIX = 'code_verifier_'
  */
 const TOKEN_STORM_LIMIT = 20
 const TOKEN_STORM_WINDOW_MS = 30_000
+
+const REFRESH_MARKER_FILE = 'refresh_in_progress.json'
+const REFRESH_MARKER_TTL_MS = 30_000
+const REFRESH_WAIT_POLL_MS = 200
 
 /** How long a flow may still be in progress, and its verifier still needed. */
 const ABANDONED_FLOW_AGE_MS = 10 * 60 * 1000
@@ -574,11 +586,62 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
    */
   private async refreshTokens(refreshToken: string): Promise<OAuthTokensWithExpiresAt | undefined> {
     if (!this.refreshInFlight) {
-      this.refreshInFlight = this.doRefreshTokens(refreshToken).finally(() => {
+      this.refreshInFlight = this.refreshOncePerHost(refreshToken).finally(() => {
         this.refreshInFlight = null
       })
     }
     return this.refreshInFlight
+  }
+
+  /**
+   * Redeems the refresh token, or waits for whichever instance is already redeeming it
+   *
+   * A host runs several instances against one server and they share a token store, so a refresh
+   * token rotated by one of them is dead in the hands of the rest.
+   *
+   * @param refreshToken The refresh token to redeem
+   * @returns The refreshed tokens, or undefined if the refresh could not be completed
+   */
+  private async refreshOncePerHost(refreshToken: string): Promise<OAuthTokensWithExpiresAt | undefined> {
+    const claimed = await claimConfigFile(
+      this.serverUrlHash,
+      REFRESH_MARKER_FILE,
+      { pid: process.pid, at: Date.now() },
+      REFRESH_MARKER_TTL_MS,
+    )
+
+    if (!claimed) {
+      const renewed = await this.awaitRefreshBySibling()
+      if (renewed) {
+        debugLog('Another instance refreshed the token')
+        return renewed
+      }
+      return undefined
+    }
+
+    try {
+      return await this.doRefreshTokens(refreshToken)
+    } finally {
+      await deleteConfigFile(this.serverUrlHash, REFRESH_MARKER_FILE)
+    }
+  }
+
+  private async awaitRefreshBySibling(): Promise<OAuthTokensWithExpiresAt | undefined> {
+    const deadline = Date.now() + REFRESH_MARKER_TTL_MS
+
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, REFRESH_WAIT_POLL_MS))
+
+      const stored = await readJsonFile<OAuthTokensWithExpiresAt>(this.serverUrlHash, 'tokens.json', OAuthTokensWithExpiresAtSchema)
+      if (stored?.expires_at !== undefined && Date.now() < stored.expires_at - 60_000) return stored
+
+      const marker = await readJsonFile<{ at: number }>(this.serverUrlHash, REFRESH_MARKER_FILE, {
+        parseAsync: async (data: any) => (typeof data?.at === 'number' ? data : null),
+      })
+      if (!marker) return undefined
+    }
+
+    return undefined
   }
 
   private async doRefreshTokens(refreshToken: string): Promise<OAuthTokensWithExpiresAt | undefined> {

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -17,7 +17,9 @@ import {
   writeTextFile,
   deleteConfigFile,
   deleteStaleConfigFiles,
-  claimConfigFile,
+  acquireConfigLease,
+  readConfigLease,
+  releaseConfigLease,
 } from './mcp-auth-config'
 import { openBrowser } from './open-browser'
 import { log, debugLog, buildRedirectUrl, MCP_REMOTE_VERSION } from './utils'
@@ -60,9 +62,24 @@ const CODE_VERIFIER_PREFIX = 'code_verifier_'
 const TOKEN_STORM_LIMIT = 20
 const TOKEN_STORM_WINDOW_MS = 30_000
 
-const REFRESH_MARKER_FILE = 'refresh_in_progress.json'
-const REFRESH_MARKER_TTL_MS = 30_000
-const REFRESH_WAIT_POLL_MS = 200
+/** Treat a token about to expire as expired, rather than sending one that will 401 in transit. */
+const TOKEN_EXPIRY_MARGIN_MS = 60_000
+
+/** The lease that keeps a rotating refresh token to one use per host. See {@link refreshOncePerHost}. */
+const REFRESH_LEASE_FILE = 'refresh_in_progress.json'
+
+/**
+ * How long an instance may hold the refresh lease.
+ *
+ * Only ever reached by an instance that is alive and stuck, since one that died is spotted by pid
+ * and its lease taken at once. So this is sized for the slowest token request worth waiting on
+ * rather than for how quickly an abandoned lease should be noticed.
+ */
+const REFRESH_LEASE_MS = 30_000
+const REFRESH_POLL_MS = 200
+
+/** Stands in for a lease when the store cannot be written at all. See {@link takeRefreshLease}. */
+const UNCOORDINATED = ''
 
 /** How long a flow may still be in progress, and its verifier still needed. */
 const ABANDONED_FLOW_AGE_MS = 10 * 60 * 1000
@@ -470,7 +487,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       // Use the persisted absolute expiry timestamp to detect imminent expiry,
       // refreshing ~60s early to avoid sending a token that is about to 401.
       const expiresAt = this.bearerExpiresAt(tokens)
-      const isExpired = expiresAt ? Date.now() >= expiresAt - 60_000 : false
+      const isExpired = expiresAt ? Date.now() >= expiresAt - TOKEN_EXPIRY_MARGIN_MS : false
 
       debugLog('Token result:', {
         found: true,
@@ -594,54 +611,91 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
-   * Redeems the refresh token, or waits for whichever instance is already redeeming it
+   * Redeems the refresh token, or waits for whichever instance is already redeeming it.
    *
    * A host runs several instances against one server and they share a token store, so a refresh
-   * token rotated by one of them is dead in the hands of the rest.
+   * token rotated by one of them is dead in the hands of the rest. {@link refreshInFlight} holds
+   * this instance to a single use; nothing held the instances to a single use between them, and a
+   * server that rotates without a grace period answers the second use by revoking the chain - a
+   * browser sign-in in return for a burst of requests that were all legitimate.
    *
-   * @param refreshToken The refresh token to redeem
+   * The callback port that arbitrates a sign-in is no help here. It is held only while a flow is
+   * running, and a refresh happens without one, so there is no existing mutex to reuse and the
+   * lease has to stand in for one. Losing the race is not fatal: the loser reads the token the
+   * winner wrote, and failing that returns undefined into the path that existed before any of this.
+   *
+   * @param refreshToken The refresh token this instance set out to redeem
    * @returns The refreshed tokens, or undefined if the refresh could not be completed
    */
   private async refreshOncePerHost(refreshToken: string): Promise<OAuthTokensWithExpiresAt | undefined> {
-    const claimed = await claimConfigFile(
-      this.serverUrlHash,
-      REFRESH_MARKER_FILE,
-      { pid: process.pid, at: Date.now() },
-      REFRESH_MARKER_TTL_MS,
-    )
+    let lease = await this.takeRefreshLease()
 
-    if (!claimed) {
-      const renewed = await this.awaitRefreshBySibling()
-      if (renewed) {
+    if (lease === undefined) {
+      const sibling = await this.awaitRefreshBySibling()
+      if (sibling.tokens) {
         debugLog('Another instance refreshed the token')
-        return renewed
+        return sibling.tokens
       }
-      return undefined
+      // A sibling that released its lease has already had its turn, and a second attempt at a
+      // token it may have spent is the storm this exists to stop. Only work it never got to is
+      // this instance's to pick up.
+      if (!sibling.abandoned) return undefined
+
+      lease = await this.takeRefreshLease()
+      if (lease === undefined) return undefined
     }
 
     try {
-      return await this.doRefreshTokens(refreshToken)
+      // A sibling may have rotated the token while this instance was reading it, or waiting for
+      // the lease, so redeem whatever is on disk now rather than what the caller set out with.
+      const stored = await readJsonFile<OAuthTokensWithExpiresAt>(this.serverUrlHash, 'tokens.json', OAuthTokensWithExpiresAtSchema)
+      return await this.doRefreshTokens(stored?.refresh_token ?? refreshToken)
     } finally {
-      await deleteConfigFile(this.serverUrlHash, REFRESH_MARKER_FILE)
+      if (lease !== UNCOORDINATED) await releaseConfigLease(this.serverUrlHash, REFRESH_LEASE_FILE, lease)
     }
   }
 
-  private async awaitRefreshBySibling(): Promise<OAuthTokensWithExpiresAt | undefined> {
-    const deadline = Date.now() + REFRESH_MARKER_TTL_MS
+  /**
+   * Takes the refresh lease.
+   *
+   * A store this instance cannot write is the refresh's own problem to report - it fails, says so,
+   * and hands back undefined the way it always did. Failing here instead would turn that into an
+   * exception out of `tokens()`, which is on the path of every outgoing request.
+   *
+   * @returns The lease, undefined if a sibling holds it, or {@link UNCOORDINATED} if no lease can be taken at all
+   */
+  private async takeRefreshLease(): Promise<string | undefined> {
+    try {
+      return await acquireConfigLease(this.serverUrlHash, REFRESH_LEASE_FILE, REFRESH_LEASE_MS)
+    } catch (error) {
+      debugLog('Could not take the refresh lease; refreshing without coordinating', error)
+      return UNCOORDINATED
+    }
+  }
 
-    while (Date.now() < deadline) {
-      await new Promise((resolve) => setTimeout(resolve, REFRESH_WAIT_POLL_MS))
+  /**
+   * Waits on the instance holding the refresh lease, until it has something to show for it.
+   *
+   * Bounded by the lease rather than by a clock of its own: an owner that died is spotted within a
+   * poll, and one that is alive but stuck runs out its {@link REFRESH_LEASE_MS} and is treated the
+   * same. Reading the token before the lease matters, because the winner writes the token first
+   * and only then lets go of the lease.
+   *
+   * @returns The token a sibling wrote, or whether it died still owing one
+   */
+  private async awaitRefreshBySibling(): Promise<{ tokens?: OAuthTokensWithExpiresAt; abandoned?: boolean }> {
+    debugLog('Waiting for the instance already refreshing this token')
+
+    for (;;) {
+      await new Promise((resolve) => setTimeout(resolve, REFRESH_POLL_MS))
 
       const stored = await readJsonFile<OAuthTokensWithExpiresAt>(this.serverUrlHash, 'tokens.json', OAuthTokensWithExpiresAtSchema)
-      if (stored?.expires_at !== undefined && Date.now() < stored.expires_at - 60_000) return stored
+      if (stored?.expires_at !== undefined && Date.now() < stored.expires_at - TOKEN_EXPIRY_MARGIN_MS) return { tokens: stored }
 
-      const marker = await readJsonFile<{ at: number }>(this.serverUrlHash, REFRESH_MARKER_FILE, {
-        parseAsync: async (data: any) => (typeof data?.at === 'number' ? data : null),
-      })
-      if (!marker) return undefined
+      const holder = await readConfigLease(this.serverUrlHash, REFRESH_LEASE_FILE, REFRESH_LEASE_MS)
+      if (!holder) return {}
+      if (!holder.live) return { abandoned: true }
     }
-
-    return undefined
   }
 
   private async doRefreshTokens(refreshToken: string): Promise<OAuthTokensWithExpiresAt | undefined> {


### PR DESCRIPTION
During a token refresh, concurrent instances fight over the same refresh token. The introduced file lock acts as a mutex: one instance creates the marker, the rest get `EEXIST` and go read `tokens.json` instead of spending a token that is already gone.

## Observed

A laptop asleep for two days. On wake, five instances started together, all holding the same expired token:

```
POST /token 401   Failed to refresh token. Please retry the request.
POST /token 200   Issued new FastMCP tokens (rotated, refresh_jti=m8FhhGsY)
POST /token 200   Issued new FastMCP tokens (rotated, refresh_jti=G9KWyswA)
GET  /authorize   ...
```

```
[1956694] Proactive token refresh failed, falling back to the stored token   x4
[1956694] Auth code received, resolving promise
```

The stored token had already been spent by a sibling, so the fallback failed too and the user was sent to a browser - two weeks of refresh chain gone to a burst of requests that were all legitimate.

## Why not the callback port

The port only arbitrates during a sign-in. In steady state nobody holds it, and a refresh happens without one, so there is no existing mutex to reuse.

## Why not the lockfile that was removed

No liveness probing, no ownership record, no staleness heuristics. A short-lived marker with a single TTL, and losing the race is not fatal: the loser reads `tokens.json`, and failing that returns undefined into the path that existed before this change.

## Who this affects

Only servers that rotate refresh tokens without a grace period. FastMCP (py) deletes the previous token on use, so any host running several instances - Claude Desktop runs two to five - hits this on the first synchronised refresh.

## On whose responsibility this is

A grace period on the server is the better fix: the previous refresh token stays valid for a few seconds after rotation, the burst is served correctly, and no client-side coordination is needed at all. That is what makes this invisible on servers that already do it. But it is not something a client can rely on across the servers people actually connect to, which is why this is here.

Comments and reworks welcome.
