### PR TITLE
fix(auth): send the requested scope on refresh_token grants (Entra AADSTS90009)

### DIFF
--- a/src/lib/device-authorization.ts
+++ b/src/lib/device-authorization.ts
@@ -196,7 +196,7 @@ async function pollForTokens(
  * The SDK picks the client authentication method but does not export applying it, so this mirrors
  * `applyClientAuthentication` from `@modelcontextprotocol/sdk/client/auth.js` for our own requests.
  */
-function applyClientAuthentication(
+export function applyClientAuthentication(
   method: string,
   clientInformation: OAuthClientInformationMixed,
   headers: Headers,

--- a/src/lib/node-oauth-client-provider.test.ts
+++ b/src/lib/node-oauth-client-provider.test.ts
@@ -1528,3 +1528,97 @@ describe('NodeOAuthClientProvider - Extra authorization parameters', () => {
     expect([...authUrl.searchParams.keys()].sort()).toEqual(['response_type', 'scope'])
   })
 })
+
+describe('NodeOAuthClientProvider - scope on refresh_token grants (Entra AADSTS90009)', () => {
+  const options: OAuthProviderOptions = {
+    serverUrl: 'https://example.com/mcp',
+    callbackPort: 8080,
+    host: 'localhost',
+    serverUrlHash: 'test-hash',
+  }
+
+  let mockReadJsonFile: any
+  let mockRefresh: any
+
+  const withClient = (client: Record<string, unknown>, tokens?: Record<string, unknown>) =>
+    mockReadJsonFile.mockImplementation(async (_hash: string, file: string) => (file === 'client_info.json' ? client : tokens))
+
+  const tokenRequest = (grantType: string, extra: Record<string, string> = {}) => new URLSearchParams({ grant_type: grantType, ...extra })
+
+  beforeEach(() => {
+    mockReadJsonFile = vi.mocked(mcpAuthConfig.readJsonFile)
+    mockRefresh = vi.mocked(refreshAuthorization)
+    vi.mocked(mcpAuthConfig.writeJsonFile).mockResolvedValue(undefined)
+    vi.mocked(mcpAuthConfig.deleteConfigFile).mockResolvedValue(undefined)
+    vi.mocked(mcpAuthConfig.acquireConfigLease).mockResolvedValue('lease-1')
+    vi.mocked(mcpAuthConfig.releaseConfigLease).mockResolvedValue(undefined)
+    withClient({ client_id: 'c1', redirect_uris: [] })
+  })
+
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('Scenario: a refresh_token grant carries client_id and the scope this client authorized with', async () => {
+    const provider = new NodeOAuthClientProvider({ ...options, staticOAuthClientMetadata: { scope: 'openid api://app/read' } as any })
+    const headers = new Headers()
+    const params = tokenRequest('refresh_token', { refresh_token: 'r1' })
+
+    await provider.addClientAuthentication(headers, params, 'https://as.example.com/token', {
+      token_endpoint_auth_methods_supported: ['none'],
+    } as any)
+
+    // The SDK skips its own client authentication once a hook exists, so the hook must supply it
+    expect(params.get('client_id')).toBe('c1')
+    // The parameter the SDK omits, and the one Entra needs when the client id is also the resource id
+    expect(params.get('scope')).toBe('openid api://app/read')
+  })
+
+  it('Scenario: an authorization_code exchange is left without a scope', async () => {
+    const provider = new NodeOAuthClientProvider({ ...options, staticOAuthClientMetadata: { scope: 'openid api://app/read' } as any })
+    const params = tokenRequest('authorization_code', { code: 'abc' })
+
+    await provider.addClientAuthentication(new Headers(), params, 'https://as.example.com/token', undefined)
+
+    expect(params.get('client_id')).toBe('c1')
+    expect(params.has('scope')).toBe(false)
+  })
+
+  it('Scenario: a scope the caller already set is kept', async () => {
+    const provider = new NodeOAuthClientProvider({ ...options, staticOAuthClientMetadata: { scope: 'openid api://app/read' } as any })
+    const params = tokenRequest('refresh_token', { refresh_token: 'r1', scope: 'api://app/read' })
+
+    await provider.addClientAuthentication(new Headers(), params, 'https://as.example.com/token', undefined)
+
+    expect(params.get('scope')).toBe('api://app/read')
+  })
+
+  it('Scenario: a confidential client keeps client_secret_basic on the header, not in the body', async () => {
+    withClient({ client_id: 'c1', client_secret: 's1', redirect_uris: [] })
+    const provider = new NodeOAuthClientProvider(options)
+    const headers = new Headers()
+    const params = tokenRequest('refresh_token', { refresh_token: 'r1' })
+
+    await provider.addClientAuthentication(headers, params, 'https://as.example.com/token', {
+      token_endpoint_auth_methods_supported: ['client_secret_basic'],
+    } as any)
+
+    expect(headers.get('Authorization')).toBe(`Basic ${Buffer.from('c1:s1').toString('base64')}`)
+    expect(params.has('client_id')).toBe(false)
+    expect(params.has('client_secret')).toBe(false)
+  })
+
+  it('Scenario: the proactive refresh hands the SDK this hook', async () => {
+    withClient(
+      { client_id: 'c1', redirect_uris: [] },
+      { access_token: 'stale', refresh_token: 'r1', token_type: 'Bearer', expires_in: 3600, expires_at: Date.now() - 1000 },
+    )
+    mockRefresh.mockResolvedValue({ access_token: 'fresh', refresh_token: 'r2', token_type: 'Bearer', expires_in: 3600 })
+    const provider = new NodeOAuthClientProvider(options)
+
+    await provider.tokens()
+
+    expect(mockRefresh).toHaveBeenCalledTimes(1)
+    expect(mockRefresh.mock.calls[0][1].addClientAuthentication).toBe(provider.addClientAuthentication)
+  })
+})

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod'
-import { OAuthClientProvider, refreshAuthorization, selectResourceURL } from '@modelcontextprotocol/sdk/client/auth.js'
+import {
+  OAuthClientProvider,
+  refreshAuthorization,
+  selectClientAuthMethod,
+  selectResourceURL,
+} from '@modelcontextprotocol/sdk/client/auth.js'
 import {
   OAuthClientInformation,
   OAuthClientInformationFull,
@@ -27,7 +32,12 @@ import { sanitizeUrl } from 'strict-url-sanitise'
 import { createHash, randomUUID } from 'node:crypto'
 import { fetchAuthorizationServerMetadata, type AuthorizationServerMetadata } from './authorization-server-metadata'
 import { getAuthorizationServerUrl, type ProtectedResourceMetadata } from './protected-resource-metadata'
-import { authorizeWithDeviceCode, supportsDeviceAuthorization, DEVICE_CODE_GRANT_TYPE } from './device-authorization'
+import {
+  applyClientAuthentication,
+  authorizeWithDeviceCode,
+  supportsDeviceAuthorization,
+  DEVICE_CODE_GRANT_TYPE,
+} from './device-authorization'
 
 /**
  * The OAuth token response only carries the relative `expires_in`, which is
@@ -430,6 +440,34 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   }
 
   /**
+   * Client authentication for every token request the SDK or this provider sends (the SDK's
+   * `executeTokenRequest`). Once a provider supplies this hook the SDK skips its own client
+   * authentication, so the hook reproduces that first, then adds the one parameter the SDK
+   * leaves out: `scope` on a `refresh_token` grant.
+   *
+   * RFC 6749 section 6 makes `scope` optional on refresh and the SDK omits it. Microsoft Entra ID
+   * reads a scopeless refresh from an app whose client id is also the resource as "requesting a
+   * token for itself" and answers `AADSTS90009`, so the session dies at every access-token expiry
+   * (modelcontextprotocol/typescript-sdk#2718, anthropics/claude-ai-mcp#840). Repeating the scope
+   * this client authorized with turns that 400 into a 200. It is a subset of the original grant,
+   * so every other server accepts it too. Authorization-code exchanges are left exactly as they were.
+   *
+   * An arrow property rather than a method: the SDK passes `provider.addClientAuthentication`
+   * around unbound (see its `auth()`), so `this` has to travel with it.
+   */
+  addClientAuthentication: NonNullable<OAuthClientProvider['addClientAuthentication']> = async (headers, params, _url, metadata) => {
+    const clientInformation = await this.clientInformation()
+    if (clientInformation) {
+      const authMethod = selectClientAuthMethod(clientInformation, metadata?.token_endpoint_auth_methods_supported ?? [])
+      applyClientAuthentication(authMethod, clientInformation, headers, params)
+    }
+    if (params.get('grant_type') === 'refresh_token' && !params.has('scope')) {
+      params.set('scope', this.getEffectiveScope())
+      debugLog('Added the requested scope to the refresh_token grant', { scope: params.get('scope') })
+    }
+  }
+
+  /**
    * Gets the client information if it exists
    * @returns The client information or undefined
    */
@@ -792,6 +830,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
         clientInformation,
         refreshToken,
         resource,
+        addClientAuthentication: this.addClientAuthentication,
       })
 
       // Goes through saveTokens so the new expiry is persisted the same way


### PR DESCRIPTION
## Problem

The MCP TypeScript SDK sends only `grant_type` and `refresh_token` on a refresh. RFC 6749 section 6 allows that. Microsoft Entra ID does not accept it when the OAuth client id is also the resource app, which is the normal shape for an MCP server behind Entra. Entra answers:

```
AADSTS90009: Application '<id>'(<id>) is requesting a token for itself.
This scenario is supported only if resource is specified using the GUID based App Identifier.
```

The message points at the wrong thing. The real cause is the missing `scope`. Without it the refresh fails at every access-token expiry, and `mcp-remote` falls back to the stored token and then to a new browser sign-in. Users see a sign-in prompt every 60 to 90 minutes.

References: modelcontextprotocol/typescript-sdk#2718 (same topology, same error) and its open fix modelcontextprotocol/typescript-sdk#2720, which targets the v2 line only. anthropics/claude-ai-mcp#840 documents the identical failure and fix on the server side.

## Change

`NodeOAuthClientProvider` now supplies the SDK's `addClientAuthentication` hook. The SDK skips its own client authentication once a hook exists, so the hook first reproduces it through `applyClientAuthentication`, the helper the device-code flow already uses (now exported), then adds one parameter: `scope`, on `refresh_token` grants only. The value is the scope this client authorized with. That is a subset of the original grant, so authorization servers that do not need it accept it too.

The proactive refresh in `tokens()` passes the same hook, so both refresh paths carry the scope. Authorization-code exchanges are unchanged.

The hook is an arrow property because the SDK passes `provider.addClientAuthentication` around unbound.

## Verification

- Five new unit tests cover: `client_id` and `scope` on a refresh, no `scope` on an authorization-code exchange, a caller-supplied `scope` kept, `client_secret_basic` on the header, and the proactive refresh handing the SDK the hook.
- `pnpm lint`, `pnpm knip`, and `pnpm test` pass (393 tests).
- Live Entra tenant, public client via dynamic registration: the same refresh token returns HTTP 400 `AADSTS90009` without `scope` and HTTP 200 with it.
- A build of this branch ran inside Claude Desktop against a CIPP MCP server behind Entra. Two forced refresh cycles in a row logged `Refreshed the access token before it expired`, rotated the refresh token each time, and completed the tool calls with no prompt.

## Compatibility

- Servers that ignore `scope` on refresh see no change in behavior.
- Clients registered with a secret keep `client_secret_basic` or `client_secret_post` as before, through the shared helper.
- No new flags. No change to the store format.

Generated with [Claude Code](https://claude.com/claude-code)
