### PR TITLE
fix: forward the callback iss to finishAuth for RFC 9207 validation

### DIFF
--- a/src/lib/connect-to-remote-server.test.ts
+++ b/src/lib/connect-to-remote-server.test.ts
@@ -39,7 +39,7 @@ vi.mock('@modelcontextprotocol/client', async (importOriginal) => {
   }
   class StreamableHTTPClientTransport {
     start = vi.fn().mockResolvedValue(undefined)
-    finishAuth = vi.fn(async (code: string) => {
+    finishAuth = vi.fn(async (code: string, _iss?: string) => {
       mockState.finishAuthCalls.push(code)
     })
     close = vi.fn().mockResolvedValue(undefined)
@@ -115,7 +115,7 @@ describe('connectToRemoteServer', () => {
     // The fix: finishAuth must run on the transport that actually handled the challenge,
     // so the stored resource_metadata URL drives token_endpoint discovery.
     expect(testTransport.finishAuth).toHaveBeenCalledTimes(1)
-    expect(testTransport.finishAuth).toHaveBeenCalledWith('auth-code-123')
+    expect(testTransport.finishAuth).toHaveBeenCalledWith('auth-code-123', undefined)
 
     // Regression guard: it must NOT be called on the main transport (which never saw the 401).
     expect(mainTransport.finishAuth).not.toHaveBeenCalled()
@@ -186,7 +186,21 @@ describe('connectToRemoteServer', () => {
     // transport is the main one, and finishAuth must run on it.
     const [mainTransport] = mockState.httpTransports
     expect(mainTransport.finishAuth).toHaveBeenCalledTimes(1)
-    expect(mainTransport.finishAuth).toHaveBeenCalledWith('auth-code-456')
+    expect(mainTransport.finishAuth).toHaveBeenCalledWith('auth-code-456', undefined)
+  })
+
+  it('forwards the callback iss to finishAuth for RFC 9207 validation (regression: IssuerMismatchError)', async () => {
+    // A server advertising `authorization_response_iss_parameter_supported: true` sends `iss` on
+    // the callback, and the SDK client rejects the exchange if it never reaches `finishAuth`.
+    const authInitializer = vi.fn().mockResolvedValue({
+      waitForAuthCode: async () => ({ code: 'auth-code-iss', iss: 'https://mcp.example.com' }),
+      skipBrowserAuth: false,
+    })
+
+    await connectToRemoteServer(null, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')
+
+    const [, testTransport] = mockState.httpTransports
+    expect(testTransport.finishAuth).toHaveBeenCalledWith('auth-code-iss', 'https://mcp.example.com')
   })
 
   // What `coordinateAuth` hands a secondary instance once a sibling has finished the browser flow:

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -75,6 +75,13 @@ export interface OAuthCallbackServerOptions {
 export type AuthCodeResult = {
   code: string
   state?: string
+  /**
+   * The `iss` query parameter from the authorization callback (RFC 9207), if the
+   * authorization server sent one. Must reach `finishAuth` unchanged: when the
+   * server advertises `authorization_response_iss_parameter_supported: true`,
+   * the SDK client rejects a missing `iss` as a mix-up-attack indicator.
+   */
+  iss?: string
 }
 
 /*

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2338,7 +2338,7 @@ export async function connectToRemoteServer(
 
       // Wait for the authorization code from the callback
       debugLog('Waiting for auth code from callback server')
-      const { code, state } = await waitForAuthCode()
+      const { code, state, iss } = await waitForAuthCode()
       debugLog('Received auth code from callback server')
 
       // The code may belong to a flow another instance started, whose verifier is not this one's
@@ -2356,7 +2356,7 @@ export async function connectToRemoteServer(
         // Complete auth on the transport that received the 401 challenge (in proxy mode this is the
         // one-off test transport, not `transport`), so the stored resource_metadata URL is used to
         // discover the correct token_endpoint. Falls back to `transport` for the with-client path.
-        await (authChallengeTransport ?? transport).finishAuth(code)
+        await (authChallengeTransport ?? transport).finishAuth(code, iss)
         debugLog('Authorization completed successfully')
 
         // Track this reason for recursion
@@ -2487,6 +2487,7 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   app.get(options.path, (req, res) => {
     const code = req.query.code as string | undefined
     const state = req.query.state as string | undefined
+    const iss = req.query.iss as string | undefined
     const authorizationError = req.query.error as string | undefined
     if (authorizationError) {
       const description = (req.query.error_description as string | undefined) ?? authorizationError
@@ -2500,7 +2501,7 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
       return
     }
 
-    const received: AuthCodeResult = { code, state }
+    const received: AuthCodeResult = { code, state, iss }
     authEverCompleted = true
     log('Auth code received, resolving promise')
     authCompletedResolve(received)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,7 +29,7 @@ import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
 import { createLazyAuthCoordinator, hasUsableTokens, serverIssuesAuthChallenge } from './lib/coordination'
 
 /** A transport that can redeem an authorization code, which the `Transport` interface does not promise. */
-type AuthCompletable = Transport & { finishAuth: (code: string) => Promise<void> }
+type AuthCompletable = Transport & { finishAuth: (code: string, iss?: string) => Promise<void> }
 
 const canFinishAuth = (transport: Transport): transport is AuthCompletable =>
   typeof (transport as Partial<AuthCompletable>).finishAuth === 'function'
@@ -202,7 +202,7 @@ async function runProxy(
           return
         }
 
-        const { code, state } = await waitForAuthCode()
+        const { code, state, iss } = await waitForAuthCode()
         // The code may belong to a flow another instance started, whose verifier is not this one's
         if (state) authProvider.useAuthorizationState(state)
 
@@ -210,7 +210,7 @@ async function runProxy(
         if (!canFinishAuth(remoteTransport)) {
           throw new Error(`${remoteTransport.constructor.name} cannot complete an authorization`)
         }
-        await remoteTransport.finishAuth(code)
+        await remoteTransport.finishAuth(code, iss)
         log('Re-authorized with the remote server')
       },
     })


### PR DESCRIPTION
## Summary

Since v0.9.0 (the v2 MCP SDK migration), OAuth login against any RFC 9207-compliant server fails on every attempt with:

```
IssuerMismatchError: Issuer mismatch in authorization response (RFC 9207): expected "https://mcp.example.com", received undefined
```

This isn't a server misconfiguration. End-to-end tracing (curl, following the state blob through `/authorize` → upstream IdP → back) confirms the target server (Cloudflare `@cloudflare/workers-oauth-provider@0.10.3`) correctly emits `iss` in its final redirect at every hop. The browser even shows "Authorization successful!" before the CLI throws.

## Root cause

The OAuth callback route (`src/lib/utils.ts`) only reads `code`, `state`, `error`, `error_description` off the callback query string:

```ts
const code = req.query.code as string | undefined
const state = req.query.state as string | undefined
const received: AuthCodeResult = { code, state }
```

`req.query.iss` is never read, and `AuthCodeResult` has no `iss` field. The code then calls the single-argument form:

```ts
await (authChallengeTransport ?? transport).finishAuth(code)
```

leaving out the optional second argument of `finishAuth`'s `(authorizationCode: string, iss?: string)` overload. Since `iss` is never passed, `@modelcontextprotocol/client@^2.0.0`'s `finishAuth()` treats it as `undefined`. Per RFC 9207 §2.4/SEP-2468, when the AS metadata declares `authorization_response_iss_parameter_supported: true`, a missing `iss` is treated as a mix-up-attack indicator and rejected — so `finishAuth` throws immediately after redeeming a perfectly valid authorization code.

The same gap exists a second time, independently, in `src/proxy.ts`'s mid-session re-authorization path (`reauthorize`): its own `waitForAuthCode()` call destructures only `{ code, state }`, its own narrower `AuthCompletable` type pins `finishAuth` to `(code: string) => Promise<void>` with no `iss` parameter at all, and its own `finishAuth(code)` call drops it the same way.

This was silent pre-v0.9.0 because `@modelcontextprotocol/sdk@^1.25.3` never validated `iss` at all — bisected the regression to v0.9.0 (commit 79ea4b1, "feat: move to the v2 MCP SDK packages"), present unchanged through the current v0.13.5.

## Fix

Both call sites just need the `iss` value carried from the callback query string through to the existing `finishAuth(authorizationCode, iss?)` overload — no new API surface:

- `src/lib/types.ts`: added `iss?: string` to `AuthCodeResult`.
- `src/lib/utils.ts`: the callback route now reads `req.query.iss`; the initial-connect flow now calls `finishAuth(code, iss)`.
- `src/proxy.ts`: widened `AuthCompletable` to `finishAuth: (code: string, iss?: string) => Promise<void>`; the `reauthorize` path now calls `finishAuth(code, iss)`.
- `src/lib/connect-to-remote-server.test.ts`: updated the two `finishAuth` call-argument assertions for the new signature, and added a regression test (`forwards the callback iss to finishAuth for RFC 9207 validation`) that fails without this fix.

## Testing

- Verified live against a production RFC 9207-compliant MCP OAuth server: the unpatched build fails every sign-in with `IssuerMismatchError`; this exact patch, built and run against the same server and account, signs in cleanly (token issued, proxy established, no error).
- `pnpm test` — 465/465 passing across all 14 test files.
- `pnpm exec tsc --noEmit` — clean.
- `pnpm exec oxfmt --check .` and `pnpm exec oxlint --deny-warnings` — clean.

## Environment

- mcp-remote: v0.13.5 (regression range v0.9.0–v0.13.5)
- Server: any RFC 9207-compliant MCP OAuth server (reproduced against `@cloudflare/workers-oauth-provider@0.10.3`)