### PR TITLE
fix(oauth): propagate RFC 9207 `iss` parameter to avoid IssuerMismatchError

### DIFF
--- a/src/lib/connect-to-remote-server.test.ts
+++ b/src/lib/connect-to-remote-server.test.ts
@@ -13,8 +13,10 @@ const mockState = vi.hoisted(() => ({
   connectFailuresRemaining: 1,
   // Number of remaining connects that should fail the way the SDK reports a refused fresh token.
   rejectedTokenFailuresRemaining: 0,
-  // Every authorization code handed to `finishAuth`, in order.
+  // Every authorization code handed to `finishAuth`, in order (extracted from the params).
   finishAuthCalls: [] as string[],
+  // The `iss` parameter passed to `finishAuth` alongside each code, parallel to finishAuthCalls.
+  finishAuthIssCalls: [] as Array<string | undefined>,
 }))
 
 vi.mock('@modelcontextprotocol/client', async (importOriginal) => {
@@ -39,8 +41,12 @@ vi.mock('@modelcontextprotocol/client', async (importOriginal) => {
   }
   class StreamableHTTPClientTransport {
     start = vi.fn().mockResolvedValue(undefined)
-    finishAuth = vi.fn(async (code: string) => {
+    finishAuth = vi.fn(async (params: URLSearchParams | string) => {
+      // Accept both URLSearchParams (RFC 9207-aware path) and plain string (legacy path).
+      const code = params instanceof URLSearchParams ? (params.get('code') ?? '') : params
+      const iss = params instanceof URLSearchParams ? (params.get('iss') ?? undefined) : undefined
       mockState.finishAuthCalls.push(code)
+      mockState.finishAuthIssCalls.push(iss)
     })
     close = vi.fn().mockResolvedValue(undefined)
     constructor(
@@ -89,6 +95,7 @@ describe('connectToRemoteServer', () => {
   beforeEach(() => {
     mockState.httpTransports.length = 0
     mockState.finishAuthCalls.length = 0
+    mockState.finishAuthIssCalls.length = 0
     mockState.connectFailuresRemaining = 1
     mockState.rejectedTokenFailuresRemaining = 0
     // Keep test output quiet; connectToRemoteServer logs to stderr.
@@ -115,7 +122,8 @@ describe('connectToRemoteServer', () => {
     // The fix: finishAuth must run on the transport that actually handled the challenge,
     // so the stored resource_metadata URL drives token_endpoint discovery.
     expect(testTransport.finishAuth).toHaveBeenCalledTimes(1)
-    expect(testTransport.finishAuth).toHaveBeenCalledWith('auth-code-123')
+    // The argument is now URLSearchParams; check the extracted code via the mock's own capture.
+    expect(mockState.finishAuthCalls).toEqual(['auth-code-123'])
 
     // Regression guard: it must NOT be called on the main transport (which never saw the 401).
     expect(mainTransport.finishAuth).not.toHaveBeenCalled()
@@ -186,7 +194,8 @@ describe('connectToRemoteServer', () => {
     // transport is the main one, and finishAuth must run on it.
     const [mainTransport] = mockState.httpTransports
     expect(mainTransport.finishAuth).toHaveBeenCalledTimes(1)
-    expect(mainTransport.finishAuth).toHaveBeenCalledWith('auth-code-456')
+    // The argument is now URLSearchParams; check the extracted code via the mock's own capture.
+    expect(mockState.finishAuthCalls).toEqual(['auth-code-456'])
   })
 
   // What `coordinateAuth` hands a secondary instance once a sibling has finished the browser flow:
@@ -262,5 +271,121 @@ describe('connectToRemoteServer', () => {
     )
 
     expect(mockState.finishAuthCalls).toEqual(['auth-code-789'])
+  })
+})
+
+// =============================================================================
+// RFC 9207 Authorization Server Issuer Identification — regression tests
+// =============================================================================
+// RFC 9207 (OAuth 2.0 Authorization Server Issuer Identification) requires that
+// authorization servers SHOULD include an `iss` parameter in the authorization
+// response. The MCP SDK v2 validates this parameter inside `finishAuth`, and
+// throws `IssuerMismatchError` when the `iss` it receives does not match the
+// server it sent the request to. mcp-remote was dropping `iss` from the OAuth
+// loopback callback, so `finishAuth` saw no issuer and raised IssuerMismatchError
+// even when the server supplied a perfectly correct one.
+
+describe('RFC 9207 – iss propagation through the OAuth loopback callback', () => {
+  beforeEach(() => {
+    mockState.httpTransports.length = 0
+    mockState.finishAuthCalls.length = 0
+    mockState.finishAuthIssCalls.length = 0
+    mockState.connectFailuresRemaining = 1
+    mockState.rejectedTokenFailuresRemaining = 0
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+  })
+
+  it('preserves iss from the authorization response and passes it to finishAuth (RFC 9207)', async () => {
+    // Simulate an authorization response that includes `iss` as required by RFC 9207.
+    // Real servers (e.g. api.sutra.sudarshanai.com) append `?code=...&state=...&iss=https%3A%2F%2F...`
+    const authInitializer = vi.fn().mockResolvedValue({
+      waitForAuthCode: async (): Promise<AuthCodeResult> => ({
+        code: 'auth-code-rfc9207',
+        state: 'opaque-state-value',
+        iss: 'https://api.sutra.sudarshanai.com',
+      }),
+      skipBrowserAuth: false,
+    })
+
+    await connectToRemoteServer(null, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')
+
+    // The code was passed through correctly.
+    expect(mockState.finishAuthCalls).toEqual(['auth-code-rfc9207'])
+
+    // The iss was preserved and forwarded – without this, IssuerMismatchError would be thrown
+    // by the SDK's RFC 9207 validation even when the issuer is correct.
+    expect(mockState.finishAuthIssCalls).toEqual(['https://api.sutra.sudarshanai.com'])
+  })
+
+  it('finishAuth receives a URLSearchParams with both code and iss set', async () => {
+    // The MCP SDK's preferred form for finishAuth is URLSearchParams.
+    // Verify the raw argument shape rather than just the captured scalars.
+    let capturedParams: unknown
+
+    const authInitializer = vi.fn().mockResolvedValue({
+      waitForAuthCode: async (): Promise<AuthCodeResult> => ({
+        code: 'auth-code-urlparams',
+        iss: 'https://api.sutra.sudarshanai.com',
+      }),
+      skipBrowserAuth: false,
+    })
+
+    await connectToRemoteServer(null, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')
+
+    // The test transport (index 1) is the one that receives the challenge and finishAuth
+    const [, testTransport] = mockState.httpTransports
+    const call = (testTransport.finishAuth as ReturnType<typeof vi.fn>).mock.calls[0]
+    capturedParams = call[0]
+
+    expect(capturedParams).toBeInstanceOf(URLSearchParams)
+    expect((capturedParams as URLSearchParams).get('code')).toBe('auth-code-urlparams')
+    expect((capturedParams as URLSearchParams).get('iss')).toBe('https://api.sutra.sudarshanai.com')
+  })
+
+  it('does not set iss in URLSearchParams when authorization response omits it (backward compat)', async () => {
+    // Servers that predate RFC 9207 (or that choose not to include iss) must still work.
+    const authInitializer = vi.fn().mockResolvedValue({
+      waitForAuthCode: async (): Promise<AuthCodeResult> => ({
+        code: 'auth-code-no-iss',
+        // iss deliberately absent
+      }),
+      skipBrowserAuth: false,
+    })
+
+    await connectToRemoteServer(null, 'https://mcp.example.com/mcp', {} as any, {}, authInitializer, 'http-first')
+
+    expect(mockState.finishAuthCalls).toEqual(['auth-code-no-iss'])
+    // iss must be absent (undefined), not an empty string, so the SDK treats it as missing.
+    expect(mockState.finishAuthIssCalls).toEqual([undefined])
+
+    // Confirm the URLSearchParams did NOT include an `iss` key at all.
+    const [, testTransport] = mockState.httpTransports
+    const call = (testTransport.finishAuth as ReturnType<typeof vi.fn>).mock.calls[0]
+    const params = call[0] as URLSearchParams
+    expect(params.has('iss')).toBe(false)
+  })
+
+  it('state handling remains intact when iss is also present (no regression)', async () => {
+    // The existing state-based PKCE flow must still work when iss is added alongside state.
+    const useAuthorizationState = vi.fn()
+    const authProvider = { useAuthorizationState } as any
+
+    const authInitializer = vi.fn().mockResolvedValue({
+      waitForAuthCode: async (): Promise<AuthCodeResult> => ({
+        code: 'auth-code-with-state',
+        state: 'csrf-protection-token',
+        iss: 'https://api.sutra.sudarshanai.com',
+      }),
+      skipBrowserAuth: false,
+    })
+
+    await connectToRemoteServer(null, 'https://mcp.example.com/mcp', authProvider, {}, authInitializer, 'http-first')
+
+    // State is still forwarded to the provider for PKCE / CSRF validation.
+    expect(useAuthorizationState).toHaveBeenCalledWith('csrf-protection-token')
+
+    // And iss is still forwarded to finishAuth for RFC 9207 validation.
+    expect(mockState.finishAuthIssCalls).toEqual(['https://api.sutra.sudarshanai.com'])
+    expect(mockState.finishAuthCalls).toEqual(['auth-code-with-state'])
   })
 })

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -71,10 +71,19 @@ export interface OAuthCallbackServerOptions {
   serverUrlHash: string
 }
 
-/** An authorization code, with the state identifying the flow it belongs to. */
+/**
+ * An authorization code, with the state and optional issuer identifying the flow it belongs to.
+ *
+ * `iss` carries the RFC 9207 `iss` parameter returned by authorization servers that include it
+ * in the redirect. The MCP SDK uses it to verify that the response came from the expected
+ * authorization server before exchanging the code. Dropping it causes an IssuerMismatchError
+ * when the server includes the parameter.
+ */
 export type AuthCodeResult = {
   code: string
   state?: string
+  /** RFC 9207 issuer identifier, when the authorization server includes it in the redirect. */
+  iss?: string
 }
 
 /*

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -2800,6 +2800,65 @@ describe('setupOAuthCallbackServerWithLongPoll', () => {
   })
 })
 
+// ==========================================================================
+// RFC 9207 – OAuth `iss` parameter propagation regression tests
+// https://www.rfc-editor.org/rfc/rfc9207
+// ==========================================================================
+describe('setupOAuthCallbackServerWithLongPoll – RFC 9207 iss extraction', () => {
+  let rfc9207Server: import('http').Server | undefined
+  const rfc9207Events = new EventEmitter()
+
+  afterEach(async () => {
+    if (rfc9207Server) {
+      await new Promise<void>((resolve) => rfc9207Server!.close(() => resolve()))
+      rfc9207Server = undefined
+    }
+  })
+
+  it('RFC 9207: extracts iss from the redirect and includes it in AuthCodeResult', async () => {
+    // An authorization server conforming to RFC 9207 appends `iss` to the redirect:
+    // GET /callback?code=AUTH_CODE&state=STATE&iss=https%3A%2F%2Fapi.sutra.sudarshanai.com
+    // Without this fix the MCP SDK receives no issuer and throws IssuerMismatchError.
+    const result = await setupOAuthCallbackServerWithLongPoll({
+      port: 0,
+      path: '/oauth/callback',
+      events: rfc9207Events,
+      serverUrlHash: 'test-hash',
+    })
+    rfc9207Server = result.server
+
+    const base = `http://127.0.0.1:${result.actualPort}/oauth/callback`
+    await fetch(`${base}?code=rfc9207-code&state=opaque-state&iss=https%3A%2F%2Fapi.sutra.sudarshanai.com`)
+
+    const received = await result.waitForAuthCode()
+
+    expect(received.code).toBe('rfc9207-code')
+    expect(received.state).toBe('opaque-state')
+    expect(received.iss).toBe('https://api.sutra.sudarshanai.com')
+  })
+
+  it('RFC 9207: iss is absent when the authorization server does not include it (backward compat)', async () => {
+    // Servers that predate RFC 9207 do not include `iss`. The field must be undefined,
+    // so the SDK treats it as absent rather than as an empty-string issuer.
+    const result = await setupOAuthCallbackServerWithLongPoll({
+      port: 0,
+      path: '/oauth/callback',
+      events: rfc9207Events,
+      serverUrlHash: 'test-hash',
+    })
+    rfc9207Server = result.server
+
+    const base = `http://127.0.0.1:${result.actualPort}/oauth/callback`
+    await fetch(`${base}?code=legacy-code&state=legacy-state`)
+
+    const received = await result.waitForAuthCode()
+
+    expect(received.code).toBe('legacy-code')
+    expect(received.state).toBe('legacy-state')
+    expect(received.iss).toBeUndefined()
+  })
+})
+
 /**
  * The 2026-07-28 revision retired the `initialize` handshake, so a desktop host that still sends one
  * cannot reach a server that has moved on - the spec's compatibility matrix puts that pair in the one

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -2338,7 +2338,7 @@ export async function connectToRemoteServer(
 
       // Wait for the authorization code from the callback
       debugLog('Waiting for auth code from callback server')
-      const { code, state } = await waitForAuthCode()
+      const { code, state, iss } = await waitForAuthCode()
       debugLog('Received auth code from callback server')
 
       // The code may belong to a flow another instance started, whose verifier is not this one's
@@ -2356,7 +2356,11 @@ export async function connectToRemoteServer(
         // Complete auth on the transport that received the 401 challenge (in proxy mode this is the
         // one-off test transport, not `transport`), so the stored resource_metadata URL is used to
         // discover the correct token_endpoint. Falls back to `transport` for the with-client path.
-        await (authChallengeTransport ?? transport).finishAuth(code)
+        // RFC 9207: pass `iss` so the SDK can validate the authorization server identity before
+        // exchanging the code. Using URLSearchParams keeps the call forward-compatible.
+        const authResponse = new URLSearchParams({ code })
+        if (iss) authResponse.set('iss', iss)
+        await (authChallengeTransport ?? transport).finishAuth(authResponse)
         debugLog('Authorization completed successfully')
 
         // Track this reason for recursion
@@ -2487,6 +2491,10 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
   app.get(options.path, (req, res) => {
     const code = req.query.code as string | undefined
     const state = req.query.state as string | undefined
+    // RFC 9207: authorization servers that support issuer identification append `iss` to the
+    // redirect. The MCP SDK validates it inside `finishAuth`; dropping it here causes an
+    // IssuerMismatchError even when the issuer is perfectly correct.
+    const iss = req.query.iss as string | undefined
     const authorizationError = req.query.error as string | undefined
     if (authorizationError) {
       const description = (req.query.error_description as string | undefined) ?? authorizationError
@@ -2500,7 +2508,7 @@ export async function setupOAuthCallbackServerWithLongPoll(options: OAuthCallbac
       return
     }
 
-    const received: AuthCodeResult = { code, state }
+    const received: AuthCodeResult = { code, state, iss }
     authEverCompleted = true
     log('Auth code received, resolving promise')
     authCompletedResolve(received)

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -29,7 +29,7 @@ import { NodeOAuthClientProvider } from './lib/node-oauth-client-provider'
 import { createLazyAuthCoordinator, hasUsableTokens, serverIssuesAuthChallenge } from './lib/coordination'
 
 /** A transport that can redeem an authorization code, which the `Transport` interface does not promise. */
-type AuthCompletable = Transport & { finishAuth: (code: string) => Promise<void> }
+type AuthCompletable = Transport & { finishAuth: (codeOrParams: string | URLSearchParams, iss?: string) => Promise<void> }
 
 const canFinishAuth = (transport: Transport): transport is AuthCompletable =>
   typeof (transport as Partial<AuthCompletable>).finishAuth === 'function'
@@ -202,7 +202,7 @@ async function runProxy(
           return
         }
 
-        const { code, state } = await waitForAuthCode()
+        const { code, state, iss } = await waitForAuthCode()
         // The code may belong to a flow another instance started, whose verifier is not this one's
         if (state) authProvider.useAuthorizationState(state)
 
@@ -210,7 +210,11 @@ async function runProxy(
         if (!canFinishAuth(remoteTransport)) {
           throw new Error(`${remoteTransport.constructor.name} cannot complete an authorization`)
         }
-        await remoteTransport.finishAuth(code)
+        // RFC 9207: pass `iss` so the SDK can validate the authorization server identity
+        // before exchanging the code.
+        const authResponse = new URLSearchParams({ code })
+        if (iss) authResponse.set('iss', iss)
+        await remoteTransport.finishAuth(authResponse)
         log('Re-authorized with the remote server')
       },
     })


### PR DESCRIPTION
## Summary

Authorization servers that include the RFC 9207 `iss` parameter can cause IssuerMismatchError because mcp-remote currently drops the parameter before calling finishAuth().

In `@modelcontextprotocol/client@2.0.0`, `finishAuth` performs RFC 9207 issuer validation when an authorization server includes the `iss` response parameter:
```ts
const { authorizationCode, iss: issParam } = await resolveAuthorizationCallbackParams(codeOrParams, iss, ...);
if (expectedIss && !issParam) {
  throw new IssuerMismatchError(...);
}
```

When `mcp-remote` dropped `iss` from the OAuth callback query parameters, the MCP SDK received no issuer information and rejected valid authorization responses with `IssuerMismatchError`.

## Changes Made

- **Preserve OAuth callback parameters**: `code`, `state`, and `iss` are now preserved from the OAuth callback in `setupOAuthCallbackServerWithLongPoll` and retained in `AuthCodeResult`.
- **Forward via URLSearchParams**: `iss` is forwarded through `URLSearchParams` (`new URLSearchParams({ code, ...(iss && { iss }) })`) to `finishAuth()`, matching the SDK's expected parameter shape and keeping issuer verification active.
- **State validation remains unchanged**: Existing state handling and PKCE / CSRF verification remain intact without regressions.
- **Legacy responses without iss remain supported**: Authorization responses that do not include `iss` leave the field `undefined`, so older servers continue to work seamlessly.
- **Comprehensive flow coverage**: Both normal connection (`connectToRemoteServer`) and proxy reauthorization (`runProxy`) paths are covered.
- **6 regression tests added**:
  - 2 HTTP-level tests in `src/lib/utils.test.ts` verifying that `setupOAuthCallbackServerWithLongPoll` extracts `iss` when present and leaves it `undefined` when absent.
  - 4 unit tests in `src/lib/connect-to-remote-server.test.ts` verifying `iss` forwarding, `URLSearchParams` construction, legacy response compatibility, and simultaneous `state` + `iss` preservation.

## Files Changed

- `src/lib/types.ts`: Add optional `iss?: string` to `AuthCodeResult`.
- `src/lib/utils.ts`: Extract `iss` from callback query params and pass `URLSearchParams` to `finishAuth`.
- `src/proxy.ts`: Forward `iss` in proxy reauthorization and update `AuthCompletable` type definition.
- `src/lib/utils.test.ts`: 2 HTTP-level regression tests for callback server `iss` handling.
- `src/lib/connect-to-remote-server.test.ts`: 4 unit tests verifying parameter propagation to `finishAuth`.

## Test Results

- **Lint / Typecheck**: `oxlint --deny-warnings && tsc && tsc -p test --noEmit` passes with 0 warnings and 0 errors.
- **Vitest Suite**:
  - Base commit (`1dd81a1b`): 460 passed, 4 failed (pre-existing Windows NTFS/network platform issues).
  - Patched revision: 466 passed, 4 failed (identical 4 pre-existing Windows platform issues).
  - All 6 new RFC 9207 tests pass.
