### PR TITLE
feat: support explicit client_credentials token endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,20 @@ way as for every other flow, and `client_secret_basic` or `client_secret_post` i
 authorization server advertises. No refresh token is involved: the credentials are the durable thing, so
 an expired token is replaced by asking for another the same way the first was obtained.
 
+If an internal server does not publish RFC 9728 or RFC 8414/OIDC discovery metadata, provide its known
+token endpoint explicitly. This skips discovery and is accepted only with `--client-credentials`:
+
+```bash
+npx mcp-remote https://example.remote/mcp \
+  --client-credentials \
+  --token-endpoint https://auth.example.com/oauth/token \
+  --static-oauth-client-info '{"client_id":"my-client","client_secret":"${MCP_CLIENT_SECRET}"}' \
+  --static-oauth-client-metadata '{"scope":"mcp.read mcp.write","token_endpoint_auth_method":"client_secret_basic"}'
+```
+
+The explicit endpoint must use HTTPS, except for an HTTP loopback endpoint. Credentials and URL
+fragments are refused in the endpoint URL, and changing the endpoint selects a separate token cache.
+
 ### Signing In Without a Browser
 
 The default flow needs a browser on this machine and a loopback port to redirect back to — which a

--- a/src/client.ts
+++ b/src/client.ts
@@ -43,6 +43,7 @@ async function runClient(
   useIdToken: boolean,
   useDeviceCode: boolean,
   useClientCredentials: boolean,
+  tokenEndpoint: string | undefined,
   authorizeResource: string | undefined,
   skipResourceParameter: boolean,
   authorizeParams: Record<string, string>,
@@ -62,7 +63,7 @@ async function runClient(
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
   log('Discovering OAuth server configuration...')
-  const discoveryResult = await discoverOAuthServerInfo(serverUrl, headers)
+  const discoveryResult = await discoverOAuthServerInfo(serverUrl, headers, tokenEndpoint)
 
   if (discoveryResult.protectedResourceMetadata) {
     log(`Discovered authorization server: ${discoveryResult.authorizationServerUrl}`)
@@ -216,6 +217,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote-client <https://s
       useIdToken,
       useDeviceCode,
       useClientCredentials,
+      tokenEndpoint,
       authorizeResource,
       skipResourceParameter,
       authorizeParams,
@@ -236,6 +238,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote-client <https://s
         useIdToken,
         useDeviceCode,
         useClientCredentials,
+        tokenEndpoint,
         authorizeResource,
         skipResourceParameter,
         authorizeParams,

--- a/src/lib/utils.test.ts
+++ b/src/lib/utils.test.ts
@@ -12,6 +12,7 @@ import {
   parseSecondsOption,
   parseAuthorizeParams,
   fetchWithMcpHeaders,
+  discoverOAuthServerInfo,
 } from './utils'
 import { getConfigDir } from './mcp-auth-config'
 import { Headers as UndiciHeaders } from 'undici'
@@ -178,6 +179,47 @@ describe('Feature: Command Line Arguments Parsing', () => {
     const result = await parseCommandLineArgs(['https://example.com/sse', '--client-credentials'], 'test usage')
 
     expect(result.useClientCredentials).toBe(true)
+  })
+
+  it('Scenario: Use an explicit token endpoint for client credentials without discovery', async () => {
+    const result = await parseCommandLineArgs(
+      ['https://example.com/mcp', '--client-credentials', '--token-endpoint', 'https://auth.example.com/oauth/token'],
+      'test usage',
+    )
+
+    expect(result.tokenEndpoint).toBe('https://auth.example.com/oauth/token')
+  })
+
+  it('Scenario: Refuse an explicit token endpoint for a user authorization flow', async () => {
+    await expect(
+      parseCommandLineArgs(['https://example.com/mcp', '--token-endpoint', 'https://auth.example.com/oauth/token'], 'test usage'),
+    ).rejects.toThrow('--client-credentials')
+  })
+
+  it('Scenario: Refuse to send client credentials to an insecure remote token endpoint', async () => {
+    await expect(
+      parseCommandLineArgs(
+        ['https://example.com/mcp', '--client-credentials', '--token-endpoint', 'http://auth.example.com/oauth/token'],
+        'test usage',
+      ),
+    ).rejects.toThrow('must use HTTPS')
+  })
+
+  it('Scenario: Skip OAuth discovery when a client-credentials token endpoint is explicit', async () => {
+    const fetchMock = vi.fn()
+    vi.stubGlobal('fetch', fetchMock)
+
+    const result = await discoverOAuthServerInfo('https://example.com/mcp', {}, 'https://auth.example.com/oauth/token')
+
+    expect(fetchMock).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      authorizationServerUrl: 'https://auth.example.com',
+      authorizationServerMetadata: {
+        issuer: 'https://auth.example.com',
+        token_endpoint: 'https://auth.example.com/oauth/token',
+      },
+    })
+    vi.unstubAllGlobals()
   })
 
   it('Scenario: Take a client secret from the environment rather than the command line', async () => {
@@ -4197,6 +4239,27 @@ describe('Feature: Server URL Hash Generation', () => {
     const hash1 = getServerUrlHash('https://example.com', '')
     const hash2 = getServerUrlHash('https://example.com')
     expect(hash1).toBe(hash2)
+  })
+
+  it('Scenario: Keep credentials for explicit token endpoints apart', () => {
+    const first = getServerUrlHash(
+      'https://example.com/mcp',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'https://auth-a.example.com/token',
+    )
+    const second = getServerUrlHash(
+      'https://example.com/mcp',
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'https://auth-b.example.com/token',
+    )
+
+    expect(first).not.toBe(second)
   })
 })
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1872,7 +1872,26 @@ export interface OAuthServerDiscoveryResult {
 export async function discoverOAuthServerInfo(
   serverUrl: string,
   headers: Record<string, string> = {},
+  tokenEndpoint?: string,
 ): Promise<OAuthServerDiscoveryResult> {
+  // Machine-to-machine deployments sometimes have a token endpoint that is known to the
+  // operator but publish neither RFC 9728 protected-resource metadata nor RFC 8414/OIDC
+  // authorization-server metadata. An explicit endpoint is sufficient for client_credentials,
+  // and avoiding the discovery probes also avoids redirects to unrelated HTML error pages.
+  if (tokenEndpoint) {
+    const endpoint = new URL(tokenEndpoint)
+    debugLog('Using the explicitly configured token endpoint; skipping OAuth discovery', {
+      tokenEndpointOrigin: endpoint.origin,
+    })
+    return {
+      authorizationServerUrl: endpoint.origin,
+      authorizationServerMetadata: {
+        issuer: endpoint.origin,
+        token_endpoint: endpoint.toString(),
+      },
+    }
+  }
+
   debugLog('Starting OAuth server discovery', { serverUrl })
 
   let wwwAuthenticateHeader: string | undefined
@@ -2983,6 +3002,41 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     log('Using the OAuth client_credentials grant; no browser will be opened and no user will be asked')
   }
 
+  // Some internal authorization servers do not publish discovery metadata. The endpoint is
+  // accepted only for the non-interactive client_credentials grant: applying it to a browser or
+  // device flow would leave the authorization endpoint and issuer undefined.
+  let tokenEndpoint: string | undefined
+  const tokenEndpointIndex = args.indexOf('--token-endpoint')
+  if (tokenEndpointIndex !== -1) {
+    if (tokenEndpointIndex >= args.length - 1 || args[tokenEndpointIndex + 1].startsWith('--')) {
+      throw new Error('--token-endpoint requires an HTTPS URL')
+    }
+    if (!useClientCredentials) {
+      throw new Error('--token-endpoint can only be used with --client-credentials')
+    }
+
+    const value = args[tokenEndpointIndex + 1].trim()
+    let endpoint: URL
+    try {
+      endpoint = new URL(value)
+    } catch {
+      throw new Error('Invalid --token-endpoint value. Expected an HTTPS URL.')
+    }
+
+    const isLoopback =
+      endpoint.protocol === 'http:' &&
+      (endpoint.hostname === 'localhost' || endpoint.hostname === '127.0.0.1' || endpoint.hostname === '[::1]')
+    if (endpoint.protocol !== 'https:' && !isLoopback) {
+      throw new Error('--token-endpoint must use HTTPS, except for an HTTP loopback endpoint')
+    }
+    if (endpoint.username || endpoint.password || endpoint.hash) {
+      throw new Error('--token-endpoint must not contain credentials or a URL fragment')
+    }
+
+    tokenEndpoint = endpoint.toString()
+    log(`Using an explicit OAuth token endpoint at ${endpoint.origin}`)
+  }
+
   // Both finish inside the provider's redirect step, so neither has a code arriving at a port
   NON_INTERACTIVE_FLOW = useDeviceCode || useClientCredentials
 
@@ -3070,7 +3124,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     process.exit(1)
   }
   // Calculate hash with all parsed parameters for cache isolation
-  const serverUrlHash = getServerUrlHash(serverUrl, authorizeResource, headers, authorizeParams, clientMetadataUrl)
+  const serverUrlHash = getServerUrlHash(serverUrl, authorizeResource, headers, authorizeParams, clientMetadataUrl, tokenEndpoint)
 
   // Set server hash globally for debug logging
   global.currentServerUrlHash = serverUrlHash
@@ -3130,6 +3184,7 @@ export async function parseCommandLineArgs(args: string[], usage: string) {
     useIdToken,
     useDeviceCode,
     useClientCredentials,
+    tokenEndpoint,
     authorizeResource,
     skipResourceParameter,
     authorizeParams,
@@ -3170,6 +3225,7 @@ export function setupSignalHandlers(cleanup: () => Promise<void>) {
  * @param headers Optional custom headers
  * @param authorizeParams Optional extra authorization parameters
  * @param clientMetadataUrl Optional Client ID Metadata Document URL used as the client_id
+ * @param tokenEndpoint Optional explicit token endpoint used by the client_credentials grant
  * @returns MD5 hash of the configuration
  */
 export function getServerUrlHash(
@@ -3178,6 +3234,7 @@ export function getServerUrlHash(
   headers?: Record<string, string>,
   authorizeParams?: Record<string, string>,
   clientMetadataUrl?: string,
+  tokenEndpoint?: string,
 ): string {
   // Include resource and headers in hash to isolate OAuth sessions
   // per unique server configuration (fixes #25)
@@ -3198,6 +3255,9 @@ export function getServerUrlHash(
   // A refresh token is bound to the client that obtained it, so tokens from a dynamic registration
   // cannot be refreshed once this client starts identifying itself by a URL instead.
   if (clientMetadataUrl) parts.push(clientMetadataUrl)
+  // Client credentials and tokens are bound to the authorization server that issued them. A
+  // changed endpoint must never inherit a token cached for the same MCP resource server.
+  if (tokenEndpoint) parts.push(tokenEndpoint)
   return crypto.createHash('md5').update(parts.join('|')).digest('hex')
 }
 

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -51,6 +51,7 @@ async function runProxy(
   useIdToken: boolean,
   useDeviceCode: boolean,
   useClientCredentials: boolean,
+  tokenEndpoint: string | undefined,
   authorizeResource: string | undefined,
   skipResourceParameter: boolean,
   authorizeParams: Record<string, string>,
@@ -73,7 +74,7 @@ async function runProxy(
   // Discover OAuth server info via Protected Resource Metadata (RFC 9728)
   // This probes the MCP server for WWW-Authenticate header and fetches PRM
   log('Discovering OAuth server configuration...')
-  const discoveryResult = await discoverOAuthServerInfo(serverUrl, headers)
+  const discoveryResult = await discoverOAuthServerInfo(serverUrl, headers, tokenEndpoint)
 
   if (discoveryResult.protectedResourceMetadata) {
     log(`Discovered authorization server: ${discoveryResult.authorizationServerUrl}`)
@@ -280,6 +281,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote <https://server-u
       useIdToken,
       useDeviceCode,
       useClientCredentials,
+      tokenEndpoint,
       authorizeResource,
       skipResourceParameter,
       authorizeParams,
@@ -303,6 +305,7 @@ parseCommandLineArgs(process.argv.slice(2), 'Usage: mcp-remote <https://server-u
         useIdToken,
         useDeviceCode,
         useClientCredentials,
+        tokenEndpoint,
         authorizeResource,
         skipResourceParameter,
         authorizeParams,


### PR DESCRIPTION
Closes #361.

Adds `--token-endpoint <URL>` for `--client-credentials` deployments whose authorization server publishes neither protected-resource nor authorization-server discovery metadata.

- skips discovery only when an explicit endpoint is supplied
- requires HTTPS except for loopback development endpoints
- rejects embedded credentials and URL fragments
- isolates cached credentials when the endpoint changes
- documents the static-client usage and adds focused coverage

Verified with:

- `corepack pnpm lint`
- `corepack pnpm knip`
- `corepack pnpm test` (469 tests)
- `corepack pnpm build`
- `corepack pnpm --dir test exec vitest run` (16 end-to-end tests)
