### PR TITLE
fix: bypass SDK discovery for explicit client_credentials endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -510,6 +510,9 @@ npx mcp-remote https://example.remote/mcp \
 
 The explicit endpoint must use HTTPS, except for an HTTP loopback endpoint. Credentials and URL
 fragments are refused in the endpoint URL, and changing the endpoint selects a separate token cache.
+Discovery is also skipped on cold startup and 401 retries. Tokens are renewed before expiry using
+the same client credentials. With an explicit endpoint, scope and resource are omitted unless
+configured; use `--static-oauth-client-metadata` for scope and `--resource` for resource.
 
 ### Signing In Without a Browser
 

--- a/src/client.ts
+++ b/src/client.ts
@@ -90,6 +90,7 @@ async function runClient(
     useIdToken,
     useDeviceCode,
     useClientCredentials,
+    tokenEndpoint,
     authorizeResource,
     skipResourceParameter,
     authorizeParams,

--- a/src/lib/explicit-client-credentials.test.ts
+++ b/src/lib/explicit-client-credentials.test.ts
@@ -1,0 +1,313 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { Client, StreamableHTTPClientTransport } from '@modelcontextprotocol/client'
+import { NodeOAuthClientProvider } from './node-oauth-client-provider'
+import { getConfigFilePath, writeJsonFile } from './mcp-auth-config'
+import type { OAuthProviderOptions } from './types'
+
+vi.mock('open', () => ({ default: vi.fn(() => Promise.reject(new Error('Browser auth must not run'))) }))
+vi.mock('./utils', () => ({
+  log: vi.fn(),
+  debugLog: vi.fn(),
+  MCP_REMOTE_VERSION: 'test',
+  buildRedirectUrl: (host: string, port: number, path: string) => `http://${host}:${port}${path}`,
+}))
+
+const serverUrl = 'https://mcp.example.test/mcp'
+const tokenEndpoint = 'https://identity.example.test/oauth2/v1/token'
+const serverUrlHash = 'explicit-client-credentials-test'
+const tool = { name: 'mcp_search', description: 'Search records', inputSchema: { type: 'object' as const } }
+const json = (status: number, body: unknown) =>
+  new Response(JSON.stringify(body), { status, headers: { 'content-type': 'application/json' } })
+
+/** Exercises the real SDK's auth discovery and retry logic, mocking only HTTP and browser launch. */
+class TestNetwork {
+  tokenRequests: Array<{ headers: Headers; params: URLSearchParams }> = []
+  mcpRequests: Array<{ method: string; bearer: string | null }> = []
+  discoveryRequests: string[] = []
+  acceptedToken = 'issued-1'
+  challengeMetadataUrl?: string
+  challengeScope?: string
+  rejectAllTokens = false
+  tokenFailure = false
+
+  fetch: typeof fetch = async (input, init) => {
+    const request = new Request(input, init)
+    if (request.url === tokenEndpoint) {
+      this.tokenRequests.push({ headers: request.headers, params: new URLSearchParams(await request.text()) })
+      if (this.tokenFailure) return json(400, { error: 'invalid_client', error_description: 'Client credentials rejected' })
+      const accessToken = `issued-${this.tokenRequests.length}`
+      this.acceptedToken = accessToken
+      return json(200, { access_token: accessToken, token_type: 'Bearer', expires_in: 3600 })
+    }
+    if (request.url !== serverUrl) {
+      this.discoveryRequests.push(request.url)
+      if (new URL(request.url).pathname === '/login') {
+        return new Response('<html>Enterprise sign-in</html>', { headers: { 'content-type': 'text/html' } })
+      }
+      return new Response(null, { status: 302, headers: { location: 'https://mcp.example.test/login' } })
+    }
+    if (request.method === 'GET') return new Response(null, { status: 405 })
+    const message = (await request.json()) as { id?: number; method: string }
+    const bearer = request.headers.get('authorization')
+    this.mcpRequests.push({ method: message.method, bearer })
+    if (this.rejectAllTokens || bearer !== `Bearer ${this.acceptedToken}`) {
+      const challenge = ['realm="MCP"']
+      if (this.challengeMetadataUrl) challenge.push(`resource_metadata="${this.challengeMetadataUrl}"`)
+      if (this.challengeScope) challenge.push(`scope="${this.challengeScope}"`)
+      return new Response('Token required', {
+        status: 401,
+        headers: { 'www-authenticate': `Bearer ${challenge.join(', ')}` },
+      })
+    }
+    if (message.id === undefined) return new Response(null, { status: 202 })
+    const result =
+      message.method === 'initialize'
+        ? { protocolVersion: '2025-03-26', capabilities: { tools: {} }, serverInfo: { name: 'mcp-simulator', version: '1' } }
+        : { tools: [tool] }
+    return json(200, { jsonrpc: '2.0', id: message.id, result })
+  }
+}
+
+describe('Explicit client credentials with an MCP server behind enterprise discovery redirects', () => {
+  let configDir: string
+  let network: TestNetwork
+  const clients: Client[] = []
+
+  beforeEach(async () => {
+    configDir = await mkdtemp(join(tmpdir(), 'mcp-remote-explicit-'))
+    vi.stubEnv('MCP_REMOTE_CONFIG_DIR', configDir)
+    network = new TestNetwork()
+    vi.stubGlobal('fetch', network.fetch)
+  })
+
+  afterEach(async () => {
+    await Promise.all(clients.splice(0).map((client) => client.close()))
+    vi.unstubAllGlobals()
+    vi.unstubAllEnvs()
+    vi.restoreAllMocks()
+    await rm(configDir, { recursive: true, force: true })
+  })
+
+  function provider(overrides: Partial<OAuthProviderOptions> = {}) {
+    return new NodeOAuthClientProvider({
+      serverUrl,
+      tokenEndpoint,
+      serverUrlHash,
+      host: 'localhost',
+      callbackPort: 0,
+      useClientCredentials: true,
+      staticOAuthClientInfo: { client_id: 'machine-client', client_secret: 'test-secret', redirect_uris: [] },
+      ...overrides,
+    })
+  }
+
+  async function connect(authProvider: NodeOAuthClientProvider) {
+    const client = new Client({ name: 'explicit-auth-regression', version: '1' }, { capabilities: {} })
+    clients.push(client)
+    await client.connect(new StreamableHTTPClientTransport(new URL(serverUrl), { authProvider }), { timeout: 2000 })
+    return client
+  }
+
+  it('initializes and lists tools from a cold cache without any discovery or browser authorization', async () => {
+    const authProvider = provider()
+    const redirect = vi.spyOn(authProvider, 'redirectToAuthorization')
+    const client = await connect(authProvider)
+
+    expect((await client.listTools()).tools).toEqual([tool])
+    expect(network.tokenRequests).toHaveLength(1)
+    expect(network.discoveryRequests).toEqual([])
+    expect(redirect).not.toHaveBeenCalled()
+    expect(network.mcpRequests.filter((request) => request.method === 'initialize')).toEqual([
+      { method: 'initialize', bearer: null },
+      { method: 'initialize', bearer: 'Bearer issued-1' },
+    ])
+    const cached = JSON.parse(await readFile(getConfigFilePath(serverUrlHash, 'tokens.json'), 'utf8'))
+    expect(cached).toMatchObject({ access_token: 'issued-1' })
+    expect(cached.expires_at).toBeGreaterThan(Date.now())
+    expect(cached.refresh_token).toBeUndefined()
+  })
+
+  it('replaces a rejected, unexpired cached token and retries initialize', async () => {
+    await writeJsonFile(serverUrlHash, 'tokens.json', {
+      access_token: 'stale-token',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      expires_at: Date.now() + 3600000,
+    })
+
+    const client = await connect(provider())
+
+    expect((await client.listTools()).tools).toEqual([tool])
+    expect(network.tokenRequests).toHaveLength(1)
+    expect(network.mcpRequests.filter((request) => request.method === 'initialize').map((request) => request.bearer)).toEqual([
+      'Bearer stale-token',
+      'Bearer issued-1',
+    ])
+    expect(network.discoveryRequests).toEqual([])
+  })
+
+  it('reacquires a token and retries tools/list after authorization expires on the server', async () => {
+    const client = await connect(provider())
+    network.acceptedToken = 'revoked'
+    network.challengeMetadataUrl = 'https://different-identity.example.test/.well-known/oauth-protected-resource'
+
+    expect((await client.listTools()).tools).toEqual([tool])
+    expect(network.tokenRequests).toHaveLength(2)
+    expect(network.mcpRequests.filter((request) => request.method === 'tools/list').map((request) => request.bearer)).toEqual([
+      'Bearer issued-1',
+      'Bearer issued-2',
+    ])
+    expect(network.discoveryRequests).toEqual([])
+  })
+
+  it('renews an expired token before tools/list on an already initialized transport', async () => {
+    const client = await connect(provider())
+    const cached = JSON.parse(await readFile(getConfigFilePath(serverUrlHash, 'tokens.json'), 'utf8'))
+    await writeJsonFile(serverUrlHash, 'tokens.json', { ...cached, expires_at: Date.now() - 1000 })
+
+    expect((await client.listTools()).tools).toEqual([tool])
+
+    expect(network.tokenRequests).toHaveLength(2)
+    expect(network.mcpRequests.filter((request) => request.method === 'tools/list')).toEqual([
+      { method: 'tools/list', bearer: 'Bearer issued-2' },
+    ])
+    expect(network.discoveryRequests).toEqual([])
+  })
+
+  it('renews an expired cached token without a refresh token before sending it, sharing concurrent renewal', async () => {
+    await writeJsonFile(serverUrlHash, 'tokens.json', {
+      access_token: 'expired',
+      token_type: 'Bearer',
+      expires_in: 3600,
+      expires_at: Date.now() - 1000,
+    })
+    const authProvider = provider()
+
+    const tokens = await Promise.all([authProvider.tokens(), authProvider.tokens(), authProvider.tokens()])
+
+    expect(tokens.map((token) => token?.access_token)).toEqual(['issued-1', 'issued-1', 'issued-1'])
+    expect(network.tokenRequests).toHaveLength(1)
+    expect(network.tokenRequests[0].params.get('grant_type')).toBe('client_credentials')
+    const client = await connect(authProvider)
+    expect((await client.listTools()).tools).toEqual([tool])
+    expect(network.mcpRequests.every((request) => request.bearer === 'Bearer issued-1')).toBe(true)
+    expect(network.discoveryRequests).toEqual([])
+  })
+
+  it.each([
+    {
+      authMethod: 'client_secret_basic',
+      authorization: `Basic ${Buffer.from('machine-client:test-secret').toString('base64')}`,
+      clientId: null,
+      clientSecret: null,
+    },
+    { authMethod: 'client_secret_post', authorization: null, clientId: 'machine-client', clientSecret: 'test-secret' },
+  ])(
+    'uses metadata $authMethod authentication over a conflicting client info method',
+    async ({ authMethod, authorization, clientId, clientSecret }) => {
+      await connect(
+        provider({
+          staticOAuthClientInfo: {
+            client_id: 'machine-client',
+            client_secret: 'test-secret',
+            redirect_uris: [],
+            token_endpoint_auth_method: authMethod === 'client_secret_basic' ? 'client_secret_post' : 'client_secret_basic',
+          },
+          staticOAuthClientMetadata: { redirect_uris: [], token_endpoint_auth_method: authMethod },
+        }),
+      )
+
+      const { headers, params } = network.tokenRequests[0]
+      expect(params.get('grant_type')).toBe('client_credentials')
+      expect(params.has('scope')).toBe(false)
+      // An explicit token endpoint does not advertise RFC 8707 support on the MCP server's behalf.
+      expect(params.has('resource')).toBe(false)
+      expect(headers.get('authorization')).toBe(authorization)
+      expect(params.get('client_id')).toBe(clientId)
+      expect(params.get('client_secret')).toBe(clientSecret)
+    },
+  )
+
+  it.each([false, true])('preserves explicit scope and honors resource omission=%s', async (skipResourceParameter) => {
+    await connect(
+      provider({
+        staticOAuthClientMetadata: { redirect_uris: [], scope: 'mcp.read' },
+        authorizeResource: 'https://mcp.example.test/api',
+        skipResourceParameter,
+      }),
+    )
+
+    expect(network.tokenRequests[0].params.get('scope')).toBe('mcp.read')
+    expect(network.tokenRequests[0].params.get('resource')).toBe(skipResourceParameter ? null : 'https://mcp.example.test/api')
+    expect(network.discoveryRequests).toEqual([])
+  })
+
+  it('preserves the configured scope when a 401 challenge requests a conflicting scope', async () => {
+    network.challengeScope = 'mcp.admin'
+    const client = await connect(provider({ staticOAuthClientMetadata: { redirect_uris: [], scope: 'mcp.read' } }))
+    network.acceptedToken = 'revoked'
+    network.challengeScope = 'mcp.write'
+
+    expect((await client.listTools()).tools).toEqual([tool])
+
+    expect(network.tokenRequests.map((request) => request.params.get('scope'))).toEqual(['mcp.read', 'mcp.read'])
+    expect(network.discoveryRequests).toEqual([])
+  })
+
+  it('retains a challenge scope across expiry and restart when the token response omits scope', async () => {
+    network.challengeScope = 'mcp.read'
+    const client = await connect(provider())
+    const cachePath = getConfigFilePath(serverUrlHash, 'tokens.json')
+    let cached = JSON.parse(await readFile(cachePath, 'utf8'))
+    expect(cached.scope).toBeUndefined()
+    expect(cached.requested_scope).toBe('mcp.read')
+    await writeJsonFile(serverUrlHash, 'tokens.json', { ...cached, expires_at: Date.now() - 1000 })
+
+    expect((await client.listTools()).tools).toEqual([tool])
+    await client.close()
+    cached = JSON.parse(await readFile(cachePath, 'utf8'))
+    await writeJsonFile(serverUrlHash, 'tokens.json', { ...cached, expires_at: Date.now() - 1000 })
+    network.challengeScope = undefined
+    const restartedClient = await connect(provider())
+
+    expect((await restartedClient.listTools()).tools).toEqual([tool])
+    expect(network.tokenRequests.map((request) => request.params.get('scope'))).toEqual(['mcp.read', 'mcp.read', 'mcp.read'])
+    expect(network.discoveryRequests).toEqual([])
+  })
+
+  it('stops after the freshly acquired token is rejected instead of starting another authorization loop', async () => {
+    network.rejectAllTokens = true
+
+    await expect(connect(provider())).rejects.toThrow(/401 after re-authentication/)
+
+    expect(network.tokenRequests).toHaveLength(1)
+    expect(network.mcpRequests).toHaveLength(2)
+    expect(network.discoveryRequests).toEqual([])
+  })
+
+  it('reports a token endpoint rejection without discovery or browser fallback', async () => {
+    network.tokenFailure = true
+    const authProvider = provider()
+    const redirect = vi.spyOn(authProvider, 'redirectToAuthorization')
+
+    await expect(connect(authProvider)).rejects.toThrow(/Client credentials rejected/)
+
+    expect(network.tokenRequests.length).toBeLessThanOrEqual(2)
+    expect(network.discoveryRequests).toEqual([])
+    expect(redirect).not.toHaveBeenCalled()
+  })
+
+  it('reports a missing client secret without a token request or browser fallback', async () => {
+    const authProvider = provider({ staticOAuthClientInfo: { client_id: 'machine-client', redirect_uris: [] } })
+    const redirect = vi.spyOn(authProvider, 'redirectToAuthorization')
+
+    await expect(connect(authProvider)).rejects.toThrow(/needs a client secret/)
+
+    expect(network.tokenRequests).toHaveLength(0)
+    expect(network.discoveryRequests).toEqual([])
+    expect(redirect).not.toHaveBeenCalled()
+  })
+})

--- a/src/lib/node-oauth-client-provider.ts
+++ b/src/lib/node-oauth-client-provider.ts
@@ -1,11 +1,19 @@
 import { z } from 'zod'
 import { OAuthClientInformationFullSchema, OAuthTokensSchema } from '@modelcontextprotocol/core'
-import { OAuthError, OAuthErrorCode, refreshAuthorization, selectClientAuthMethod, selectResourceURL } from '@modelcontextprotocol/client'
+import {
+  auth,
+  OAuthError,
+  OAuthErrorCode,
+  refreshAuthorization,
+  selectClientAuthMethod,
+  selectResourceURL,
+} from '@modelcontextprotocol/client'
 import type {
   OAuthClientInformation,
   OAuthClientInformationFull,
   OAuthClientInformationMixed,
   OAuthClientProvider,
+  OAuthDiscoveryState,
   OAuthTokens,
 } from '@modelcontextprotocol/client'
 import { type OAuthProviderOptions, type StaticOAuthClientInformationFull, type StaticOAuthClientMetadata } from './types'
@@ -229,6 +237,8 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   private recentAuthorizations: number[] = []
   /** In-flight proactive refresh, so concurrent requests share one refresh_token use */
   private refreshInFlight: Promise<OAuthTokensWithExpiresAt | undefined> | null = null
+  /** Concurrent requests share one client_credentials renewal, which has no refresh token. */
+  private clientCredentialsInFlight: Promise<void> | null = null
   /**
    * The sign-in being started, so concurrent arms join it rather than race it.
    *
@@ -277,6 +287,10 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     } else if (this.authorizeResource) {
       const resourceUrl = new URL(this.authorizeResource)
       this.validateResourceURL = async () => resourceUrl
+    } else if (this.hasExplicitTokenEndpoint) {
+      // The SDK needs resource metadata to skip discovery, but our configured state is not a
+      // server advertisement of RFC 8707 support. Preserve the no-metadata resource default.
+      this.validateResourceURL = async () => undefined
     }
     // Otherwise left undefined so the SDK applies its default resource selection.
   }
@@ -285,8 +299,49 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     this.options.callbackPort = port
   }
 
-  get redirectUrl(): string {
+  private get hasExplicitTokenEndpoint(): boolean {
+    return this.useClientCredentials && !!this.options.tokenEndpoint
+  }
+
+  get redirectUrl(): string | undefined {
+    // This selects the SDK's non-interactive token exchange, before it builds a PKCE redirect.
+    if (this.hasExplicitTokenEndpoint) return undefined
     return buildRedirectUrl(this.options.host, this.options.callbackPort, this.callbackPath)
+  }
+
+  discoveryState(): OAuthDiscoveryState | undefined {
+    if (!this.hasExplicitTokenEndpoint) return undefined
+    const endpoint = new URL(this.options.tokenEndpoint!)
+    return {
+      authorizationServerUrl: endpoint.origin,
+      authorizationServerMetadata: {
+        issuer: endpoint.origin,
+        token_endpoint: endpoint.href,
+        grant_types_supported: ['client_credentials'],
+        // The SDK types full OAuth/OIDC documents, but this grant has no authorization endpoint.
+      } as unknown as OAuthDiscoveryState['authorizationServerMetadata'],
+      // Both layers must be present: the SDK otherwise still probes protected-resource metadata
+      // after a 401, even when the authorization server and token endpoint are already known.
+      resourceMetadata: { resource: this.resourceServerUrl, authorization_servers: [endpoint.origin] },
+    }
+  }
+
+  async prepareTokenRequest(scope?: string): Promise<URLSearchParams | undefined> {
+    if (!this.hasExplicitTokenEndpoint) return undefined
+    if (this.inTokenStorm()) throw this.tokenStormError()
+    const clientInformation = await this.clientInformation()
+    if (!clientInformation?.client_secret) {
+      throw new Error('The client_credentials grant needs a client secret; supply it with --static-oauth-client-info')
+    }
+    const params = new URLSearchParams({ grant_type: 'client_credentials' })
+    // Keep an operator-pinned scope authoritative even when a 401 challenges for another scope.
+    const effectiveScope = this.staticOAuthClientMetadata?.scope?.trim() || scope
+    if (effectiveScope) params.set('scope', effectiveScope)
+    // saveTokens records this request so a renewal, including after restart, can repeat a scope
+    // learned from the challenge even when the token response omits its optional scope field.
+    this.wwwAuthenticateScope = effectiveScope
+    log(`Requesting a token from ${new URL(this.options.tokenEndpoint!).origin} with the client_credentials grant`)
+    return params
   }
 
   /**
@@ -301,7 +356,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   get clientMetadata() {
     const effectiveScope = this.getEffectiveScope()
     return {
-      redirect_uris: [this.redirectUrl],
+      redirect_uris: this.redirectUrl ? [this.redirectUrl] : [],
       token_endpoint_auth_method: this.getTokenEndpointAuthMethod(),
       grant_types: this.grantTypes(),
       response_types: ['code'],
@@ -409,7 +464,7 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   }
 
   private getEffectiveScope(): string {
-    return this.requestedScope() ?? FALLBACK_SCOPE
+    return this.requestedScope() ?? (this.hasExplicitTokenEndpoint ? '' : FALLBACK_SCOPE)
   }
 
   private requestedScope(): string | undefined {
@@ -484,7 +539,12 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
   addClientAuthentication: NonNullable<OAuthClientProvider['addClientAuthentication']> = async (headers, params, _url, metadata) => {
     const clientInformation = await this.clientInformation()
     if (clientInformation) {
-      const authMethod = selectClientAuthMethod(clientInformation, metadata?.token_endpoint_auth_methods_supported ?? [])
+      const authMethod = selectClientAuthMethod(
+        this.hasExplicitTokenEndpoint && this.staticOAuthClientMetadata?.token_endpoint_auth_method
+          ? { ...clientInformation, token_endpoint_auth_method: this.staticOAuthClientMetadata.token_endpoint_auth_method }
+          : clientInformation,
+        metadata?.token_endpoint_auth_methods_supported ?? [],
+      )
       applyClientAuthentication(authMethod, clientInformation, headers, params)
     }
     if (params.get('grant_type') === 'refresh_token' && !params.has('scope')) {
@@ -657,6 +717,14 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
       // Waiting for a 401 assumes the server answers expiry with exactly 401 -
       // one that replies 400 or 403 instead never reaches the SDK's refresh path
       // and the connection just fails (see issue #273).
+      if (isExpired && this.hasExplicitTokenEndpoint) {
+        await this.renewClientCredentials(tokens.requested_scope ?? tokens.scope)
+        // Read the newly persisted token directly: a short-lived token may already fall inside
+        // the expiry margin, and recursively calling tokens() would immediately renew it again.
+        return this.asBearerTokens(
+          await readJsonFile<OAuthTokensWithExpiresAt>(this.serverUrlHash, 'tokens.json', OAuthTokensWithExpiresAtSchema),
+        )
+      }
       if (isExpired && tokens.refresh_token) {
         const refreshed = await this.refreshTokens(tokens.refresh_token)
         if (refreshed) {
@@ -671,6 +739,19 @@ export class NodeOAuthClientProvider implements OAuthClientProvider {
     }
 
     return this.asBearerTokens(tokens)
+  }
+
+  private async renewClientCredentials(scope?: string): Promise<void> {
+    if (!this.clientCredentialsInFlight) {
+      // The SDK's non-interactive path does not call tokens(), so this cannot recurse. Use the
+      // same configured endpoint, scope, resource and client authentication as its 401 retry.
+      this.clientCredentialsInFlight = auth(this, { serverUrl: this.resourceServerUrl, scope })
+        .then(() => {})
+        .finally(() => {
+          this.clientCredentialsInFlight = null
+        })
+    }
+    await this.clientCredentialsInFlight
   }
 
   /**

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,8 @@ export interface OAuthProviderOptions {
   useDeviceCode?: boolean
   /** Sign in as the software itself with the RFC 6749 `client_credentials` grant */
   useClientCredentials?: boolean
+  /** Explicit client_credentials token endpoint; bypasses OAuth discovery throughout authentication. */
+  tokenEndpoint?: string
   /** Resource parameter to send to the authorization server */
   authorizeResource?: string
   /** Omit the RFC 8707 resource parameter entirely (some servers reject it, e.g. Entra ID v2) */

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -101,6 +101,7 @@ async function runProxy(
     useIdToken,
     useDeviceCode,
     useClientCredentials,
+    tokenEndpoint,
     authorizeResource,
     skipResourceParameter,
     authorizeParams,


### PR DESCRIPTION
- Follow-up to #362.

`--token-endpoint` skips mcp-remote’s initial discovery, but the SDK still attempts discovery after a 401. Servers without discovery metadata therefore fail before reaching the configured token endpoint.

This connects explicit endpoints to the SDK’s noninteractive client-credentials flow and supplies both discovery-state layers. Cold startup and 401 retries use the configured endpoint directly. Expired tokens are reacquired without a refresh token, with concurrent renewal requests sharing one exchange.

The change also preserves configured authentication methods, scope precedence, scope across renewal and restart, and resource parameter settings. Adds 14 regression tests using the real SDK transport and generic fixtures.